### PR TITLE
Update workflows and introduce environment configuration

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -10,6 +10,10 @@ jobs:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.head.ref, 'staging') && !contains(github.event.pull_request.head.ref, 'production')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        run: |
+          gh auth setup-git
+          gh api \
+            --method DELETE \
+            repos/${{ github.repository }}/git/refs/heads/${{ github.event.pull_request.head.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,13 +41,14 @@ jobs:
           yarn nx affected -t e2e
 
       - name: Build for deployment
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/production')
+        env:
+          APP_VERSION: ${{ steps.get_version.outputs.version }}
         run: |
-          npx nx build client --configuration=production \
-          --define "process.env.APP_VERSION=${{ steps.get_version.outputs.version }}"
+          npx nx build client --configuration=production
 
       - name: Upload build artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/staging' || github.ref == 'refs/heads/production')
         uses: actions/upload-artifact@v4
         with:
           name: dist

--- a/apps/client/src/environments/environment.prod.ts
+++ b/apps/client/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: true,
+    version: process.env['APP_VERSION'] || 'unknown',
+};

--- a/apps/client/src/environments/environment.ts
+++ b/apps/client/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: false,
+    version: 'dev',
+};


### PR DESCRIPTION
- Replace `delete-merged-branch` action with direct `gh api` call for branch cleanup.
- Restrict build and artifact upload steps to staging/production branches.
- Add environment configuration files for differentiating production and development builds.