### PR TITLE
Update cleanup workflow to fix branch deletion permissions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write # Required for branch deletion
+
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
@@ -11,7 +14,6 @@ jobs:
     steps:
       - name: Delete merged branch
         run: |
-          gh auth setup-git
           gh api \
             --method DELETE \
             repos/${{ github.repository }}/git/refs/heads/${{ github.event.pull_request.head.ref }}


### PR DESCRIPTION
- Add `contents: write` permission for branch deletion.
- Remove unnecessary `gh auth setup-git` step.