### PR TITLE
feat(api-tests): add comprehensive auth endpoint integration tests

### DIFF
--- a/apps/client-e2e/src/api/api-auth.spec.ts
+++ b/apps/client-e2e/src/api/api-auth.spec.ts
@@ -1,0 +1,525 @@
+import { test, expect } from '@playwright/test';
+import {
+    API_BASE_URL,
+    apiGet,
+    apiPost,
+    getCsrfToken,
+    expectSecurityHeaders,
+    ALLOWED_ORIGINS,
+} from './api-test-helpers';
+
+/**
+ * API Integration Tests - Authentication Endpoints
+ * Tests for Tasks 1.3-1.5: Auth API Implementation
+ *
+ * These tests verify:
+ * - GET /api/auth/csrf - CSRF token endpoint (Task 1.3.1)
+ * - GET /api/auth/me - Current user endpoint (Task 1.4)
+ * - POST /api/auth/login - Login endpoint (Task 1.3)
+ * - POST /api/auth/logout - Logout endpoint (Task 1.5)
+ */
+
+/**
+ * User data response from /api/auth/me
+ */
+interface AuthMeResponse {
+    isAuthenticated: boolean;
+    user?: {
+        login: string;
+        name?: string;
+        email?: string;
+        role?: string;
+        permissions?: string[];
+    };
+}
+
+/**
+ * Login response data
+ */
+interface LoginResponse {
+    user: {
+        login: string;
+        name?: string;
+        email?: string;
+        role?: string;
+        permissions?: string[];
+    };
+    csrfToken: string;
+}
+
+/**
+ * CSRF token response
+ */
+interface CsrfResponse {
+    csrfToken: string;
+}
+
+// Use first allowed origin for tests
+const allowedOrigin = ALLOWED_ORIGINS[0];
+
+test.describe('Auth API - CSRF Token Endpoint (Task 1.3.1)', () => {
+    test.describe('GET /api/auth/csrf', () => {
+        test('should return CSRF token', async ({ request }) => {
+            const { response, body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+
+            expect(response.status()).toBe(200);
+            expect(body.success).toBe(true);
+            expect(body.data).toHaveProperty('csrfToken');
+            expect(typeof body.data?.csrfToken).toBe('string');
+        });
+
+        test('should return token of at least 64 hex characters (256 bits)', async ({ request }) => {
+            const { body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+
+            expect(body.data?.csrfToken.length).toBeGreaterThanOrEqual(64);
+            // Should be hex string
+            expect(body.data?.csrfToken).toMatch(/^[a-f0-9]+$/i);
+        });
+
+        test('should include security headers', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`);
+
+            expectSecurityHeaders(response);
+        });
+
+        test('should include cache prevention headers', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`);
+            const headers = response.headers();
+
+            // CSRF token should not be cached
+            expect(headers['cache-control']).toContain('no-store');
+        });
+
+        test('should return consistent token for same session', async ({ request }) => {
+            const { body: body1 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+            const { body: body2 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+
+            expect(body1.data?.csrfToken).toBe(body2.data?.csrfToken);
+        });
+
+        test('should work without Origin header (public endpoint)', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`, {
+                headers: {
+                    Accept: 'application/json',
+                    // No Origin header
+                },
+            });
+
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(body.success).toBe(true);
+            expect(body.data).toHaveProperty('csrfToken');
+        });
+    });
+});
+
+test.describe('Auth API - Current User Endpoint (Task 1.4)', () => {
+    test.describe('GET /api/auth/me', () => {
+        test('should return isAuthenticated: false for guest', async ({ request }) => {
+            const { response, body } = await apiGet<AuthMeResponse>(request, '/api/auth/me');
+
+            expect(response.status()).toBe(200);
+            expect(body.success).toBe(true);
+            expect(body.data?.isAuthenticated).toBe(false);
+        });
+
+        test('should not require Origin header (read-only endpoint)', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
+                headers: {
+                    Accept: 'application/json',
+                    // No Origin header
+                },
+            });
+
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(body.success).toBe(true);
+        });
+
+        test('should include security headers', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`);
+
+            expectSecurityHeaders(response);
+        });
+
+        test('should have correct JSON content type', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`);
+            const contentType = response.headers()['content-type'];
+
+            expect(contentType).toContain('application/json');
+        });
+    });
+});
+
+test.describe('Auth API - Login Endpoint (Task 1.3)', () => {
+    test.describe('POST /api/auth/login - Security', () => {
+        test('should reject login without CSRF token', async ({ request }) => {
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'testuser', password: 'testpass' },
+                origin: allowedOrigin,
+                // No CSRF token
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('CSRF_VALIDATION_FAILED');
+        });
+
+        test('should reject login without Origin header', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    // No Origin or Referer
+                },
+                data: { username: 'testuser', password: 'testpass' },
+            });
+
+            const body = await response.json();
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_REQUIRED');
+        });
+
+        test('should reject login from disallowed origin', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'testuser', password: 'testpass' },
+                origin: 'https://evil-site.com',
+                csrfToken,
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_NOT_ALLOWED');
+        });
+
+        test('should include security headers in response', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    Origin: allowedOrigin,
+                },
+                data: { username: 'invalid', password: 'invalid' },
+            });
+
+            expectSecurityHeaders(response);
+        });
+    });
+
+    test.describe('POST /api/auth/login - Validation', () => {
+        test('should reject empty username', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: '', password: 'somepassword' },
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Either 400 (validation) or 401 (authentication failed)
+            expect([400, 401]).toContain(response.status());
+            expect(body.success).toBe(false);
+        });
+
+        test('should reject empty password', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'testuser', password: '' },
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Either 400 (validation) or 401 (authentication failed)
+            expect([400, 401]).toContain(response.status());
+            expect(body.success).toBe(false);
+        });
+
+        test('should return 401 for invalid credentials', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'nonexistent_user_12345', password: 'wrong_password' },
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            expect(response.status()).toBe(401);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('INVALID_CREDENTIALS');
+        });
+    });
+
+    test.describe('POST /api/auth/login - Response Format', () => {
+        test('should return JSON content type', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    Origin: allowedOrigin,
+                },
+                data: { username: 'test', password: 'test' },
+            });
+
+            const contentType = response.headers()['content-type'];
+            expect(contentType).toContain('application/json');
+        });
+
+        test('should have consistent error response structure', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'invalid', password: 'invalid' },
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Error response should have these fields
+            expect(body).toHaveProperty('success', false);
+            expect(body).toHaveProperty('error');
+            expect(body).toHaveProperty('errorCode');
+        });
+    });
+});
+
+test.describe('Auth API - Logout Endpoint (Task 1.5)', () => {
+    test.describe('POST /api/auth/logout - Security', () => {
+        test('should reject logout without CSRF token', async ({ request }) => {
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
+                origin: allowedOrigin,
+                // No CSRF token
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('CSRF_VALIDATION_FAILED');
+        });
+
+        test('should reject logout without Origin header', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    // No Origin or Referer
+                },
+            });
+
+            const body = await response.json();
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_REQUIRED');
+        });
+
+        test('should reject logout from disallowed origin', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
+                origin: 'https://evil-site.com',
+                csrfToken,
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_NOT_ALLOWED');
+        });
+
+        test('should include security headers', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    Origin: allowedOrigin,
+                },
+            });
+
+            expectSecurityHeaders(response);
+        });
+    });
+
+    test.describe('POST /api/auth/logout - Functionality', () => {
+        test('should succeed for guest user (idempotent)', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Logout should succeed even for guest (idempotent operation)
+            expect(response.status()).toBe(200);
+            expect(body.success).toBe(true);
+        });
+
+        test('after logout, /api/auth/me should return isAuthenticated: false', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            // Perform logout
+            await apiPost(request, '/api/auth/logout', {
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Check auth status
+            const { body } = await apiGet<AuthMeResponse>(request, '/api/auth/me');
+
+            expect(body.success).toBe(true);
+            expect(body.data?.isAuthenticated).toBe(false);
+        });
+    });
+});
+
+test.describe('Auth API - Full Authentication Flow', () => {
+    test('complete flow: csrf → login (fail) → me (guest)', async ({ request }) => {
+        // Step 1: Get CSRF token
+        const { body: csrfBody } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+        expect(csrfBody.success).toBe(true);
+        const csrfToken = csrfBody.data!.csrfToken;
+
+        // Step 2: Attempt login with invalid credentials
+        const { response: loginResponse, body: loginBody } = await apiPost<LoginResponse>(
+            request,
+            '/api/auth/login',
+            {
+                data: { username: 'invalid_user', password: 'invalid_pass' },
+                origin: allowedOrigin,
+                csrfToken,
+            }
+        );
+
+        expect(loginResponse.status()).toBe(401);
+        expect(loginBody.success).toBe(false);
+        expect(loginBody.errorCode).toBe('INVALID_CREDENTIALS');
+
+        // Step 3: Check we're still guest
+        const { body: meBody } = await apiGet<AuthMeResponse>(request, '/api/auth/me');
+        expect(meBody.success).toBe(true);
+        expect(meBody.data?.isAuthenticated).toBe(false);
+    });
+
+    test('CSRF token regeneration after logout', async ({ request }) => {
+        // Get initial CSRF token
+        const { body: csrf1 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+        const token1 = csrf1.data!.csrfToken;
+
+        // Perform logout (should regenerate session)
+        await apiPost(request, '/api/auth/logout', {
+            origin: allowedOrigin,
+            csrfToken: token1,
+        });
+
+        // Get new CSRF token (may or may not be different depending on session handling)
+        const { body: csrf2 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+        const token2 = csrf2.data!.csrfToken;
+
+        // Both tokens should be valid format
+        expect(token1.length).toBeGreaterThanOrEqual(64);
+        expect(token2.length).toBeGreaterThanOrEqual(64);
+        expect(token1).toMatch(/^[a-f0-9]+$/i);
+        expect(token2).toMatch(/^[a-f0-9]+$/i);
+    });
+});
+
+test.describe('Auth API - X-XSRF-TOKEN Header Support (Angular)', () => {
+    test('login should accept X-XSRF-TOKEN header', async ({ request }) => {
+        const csrfToken = await getCsrfToken(request);
+
+        const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                Origin: allowedOrigin,
+                'X-XSRF-TOKEN': csrfToken, // Angular-style header
+            },
+            data: { username: 'test', password: 'test' },
+        });
+
+        // Should not return CSRF error (may return 401 for invalid credentials)
+        const body = await response.json();
+        if (response.status() === 403) {
+            expect(body.errorCode).not.toBe('CSRF_VALIDATION_FAILED');
+        }
+    });
+
+    test('logout should accept X-XSRF-TOKEN header', async ({ request }) => {
+        const csrfToken = await getCsrfToken(request);
+
+        const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                Origin: allowedOrigin,
+                'X-XSRF-TOKEN': csrfToken, // Angular-style header
+            },
+        });
+
+        const body = await response.json();
+
+        // Should succeed (not CSRF error)
+        expect(response.status()).toBe(200);
+        expect(body.success).toBe(true);
+    });
+});
+
+test.describe('Auth API - Referer Fallback', () => {
+    test('login should accept Referer when Origin is missing', async ({ request }) => {
+        const csrfToken = await getCsrfToken(request);
+
+        const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                'X-CSRF-Token': csrfToken,
+                Referer: `${allowedOrigin}/login`,
+                // No Origin header
+            },
+            data: { username: 'test', password: 'test' },
+        });
+
+        const body = await response.json();
+
+        // Should not get ORIGIN_REQUIRED error
+        if (response.status() === 403) {
+            expect(body.errorCode).not.toBe('ORIGIN_REQUIRED');
+        }
+    });
+
+    test('logout should accept Referer when Origin is missing', async ({ request }) => {
+        const csrfToken = await getCsrfToken(request);
+
+        const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+                'X-CSRF-Token': csrfToken,
+                Referer: `${allowedOrigin}/dashboard`,
+                // No Origin header
+            },
+        });
+
+        const body = await response.json();
+
+        // Should succeed
+        expect(response.status()).toBe(200);
+        expect(body.success).toBe(true);
+    });
+});

--- a/apps/client-e2e/src/api/api-auth.spec.ts
+++ b/apps/client-e2e/src/api/api-auth.spec.ts
@@ -6,6 +6,9 @@ import {
     getCsrfToken,
     expectSecurityHeaders,
     ALLOWED_ORIGINS,
+    CsrfResponse,
+    AuthMeResponse,
+    LoginResponse,
 } from './api-test-helpers';
 
 /**
@@ -18,41 +21,6 @@ import {
  * - POST /api/auth/login - Login endpoint (Task 1.3)
  * - POST /api/auth/logout - Logout endpoint (Task 1.5)
  */
-
-/**
- * User data response from /api/auth/me
- */
-interface AuthMeResponse {
-    isAuthenticated: boolean;
-    user?: {
-        login: string;
-        name?: string;
-        email?: string;
-        role?: string;
-        permissions?: string[];
-    };
-}
-
-/**
- * Login response data
- */
-interface LoginResponse {
-    user: {
-        login: string;
-        name?: string;
-        email?: string;
-        role?: string;
-        permissions?: string[];
-    };
-    csrfToken: string;
-}
-
-/**
- * CSRF token response
- */
-interface CsrfResponse {
-    csrfToken: string;
-}
 
 // Use first allowed origin for tests
 const allowedOrigin = ALLOWED_ORIGINS[0];

--- a/apps/client-e2e/src/api/api-basic.spec.ts
+++ b/apps/client-e2e/src/api/api-basic.spec.ts
@@ -3,6 +3,8 @@ import {
     API_BASE_URL,
     apiGet,
     expectSecurityHeaders,
+    CsrfResponse,
+    AuthMeResponse,
 } from './api-test-helpers';
 
 /**
@@ -16,42 +18,9 @@ import {
  */
 
 test.describe('API Basic Endpoints', () => {
-    test.describe('GET /api/test/ping', () => {
-        test('should return successful ping response', async ({ request }) => {
-            const { response, body } = await apiGet(request, '/api/test/ping');
-
-            expect(response.status()).toBe(200);
-            expect(body.success).toBe(true);
-            expect(body.data).toHaveProperty('message', 'pong');
-            expect(body.data).toHaveProperty('timestamp');
-            expect(body.data).toHaveProperty('version');
-        });
-
-        test('should return JSON content type', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`);
-            const contentType = response.headers()['content-type'];
-
-            expect(contentType).toContain('application/json');
-        });
-
-        test('should include security headers', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`);
-
-            expectSecurityHeaders(response);
-        });
-
-        test('should not require authentication', async ({ request }) => {
-            // Fresh request without any cookies/session
-            const { response, body } = await apiGet(request, '/api/test/ping');
-
-            expect(response.status()).toBe(200);
-            expect(body.success).toBe(true);
-        });
-    });
-
-    test.describe('GET /api/test/csrf', () => {
+    test.describe('GET /api/auth/csrf', () => {
         test('should return CSRF token', async ({ request }) => {
-            const { response, body } = await apiGet(request, '/api/test/csrf');
+            const { response, body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
 
             expect(response.status()).toBe(200);
             expect(body.success).toBe(true);
@@ -61,35 +30,71 @@ test.describe('API Basic Endpoints', () => {
             expect(body.data?.csrfToken.length).toBeGreaterThanOrEqual(64);
         });
 
-        test('should include no-cache headers for CSRF endpoint', async ({
-            request,
-        }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/csrf`);
+        test('should return JSON content type', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`);
+            const contentType = response.headers()['content-type'];
 
-            // Cache-Control header may not be set - this is a potential improvement
-            // For now, just verify the endpoint works
-            expect(response.status()).toBe(200);
-            // TODO: Backend should add Cache-Control: no-store for CSRF endpoint
-            // expect(headers['cache-control']).toContain('no-store');
+            expect(contentType).toContain('application/json');
         });
 
-        test('should return same token for same session', async ({
-            request,
-        }) => {
+        test('should include security headers', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`);
+
+            expectSecurityHeaders(response);
+        });
+
+        test('should include no-cache headers for CSRF endpoint', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`);
+            const headers = response.headers();
+
+            // CSRF token should not be cached
+            expect(headers['cache-control']).toContain('no-store');
+        });
+
+        test('should return same token for same session', async ({ request }) => {
             // First request
-            const { body: body1 } = await apiGet(request, '/api/test/csrf');
+            const { body: body1 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
             // Second request (same session via Playwright context)
-            const { body: body2 } = await apiGet(request, '/api/test/csrf');
+            const { body: body2 } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
 
             expect(body1.data?.csrfToken).toBe(body2.data?.csrfToken);
+        });
+
+        test('should not require authentication', async ({ request }) => {
+            // Fresh request without any cookies/session
+            const { response, body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
+
+            expect(response.status()).toBe(200);
+            expect(body.success).toBe(true);
+        });
+    });
+
+    test.describe('GET /api/auth/me', () => {
+        test('should return isAuthenticated: false for guest', async ({ request }) => {
+            const { response, body } = await apiGet<AuthMeResponse>(request, '/api/auth/me');
+
+            expect(response.status()).toBe(200);
+            expect(body.success).toBe(true);
+            expect(body.data?.isAuthenticated).toBe(false);
+        });
+
+        test('should return JSON content type', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`);
+            const contentType = response.headers()['content-type'];
+
+            expect(contentType).toContain('application/json');
+        });
+
+        test('should include security headers', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`);
+
+            expectSecurityHeaders(response);
         });
     });
 
     test.describe('API Response Format', () => {
-        test('should have consistent response structure', async ({
-            request,
-        }) => {
-            const { body } = await apiGet(request, '/api/test/ping');
+        test('should have consistent response structure', async ({ request }) => {
+            const { body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
 
             // All API responses should have 'success' field
             expect(body).toHaveProperty('success');
@@ -99,6 +104,16 @@ test.describe('API Basic Endpoints', () => {
             if (body.success) {
                 expect(body).toHaveProperty('data');
             }
+        });
+
+        test('error response should have consistent structure', async ({ request }) => {
+            // Try to access non-existent endpoint
+            const response = await request.get(`${API_BASE_URL}/api/auth/nonexistent`);
+            const body = await response.json();
+
+            expect(response.status()).toBe(404);
+            expect(body).toHaveProperty('success', false);
+            expect(body).toHaveProperty('error');
         });
     });
 });

--- a/apps/client-e2e/src/api/api-cors.spec.ts
+++ b/apps/client-e2e/src/api/api-cors.spec.ts
@@ -28,7 +28,7 @@ test.describe('CORS Headers', () => {
 
     test.describe('OPTIONS Preflight', () => {
         test('should return 204 for preflight from allowed origin', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/csrf`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: allowedOrigin,
@@ -41,7 +41,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('preflight should include all required CORS headers', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/csrf`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: allowedOrigin,
@@ -71,7 +71,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('preflight should NOT include CORS headers for disallowed origin', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/csrf`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: TEST_DISALLOWED_ORIGIN,
@@ -87,7 +87,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('preflight from disallowed origin should return 403', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/csrf`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: TEST_DISALLOWED_ORIGIN,
@@ -102,7 +102,7 @@ test.describe('CORS Headers', () => {
 
     test.describe('Vary: Origin Header', () => {
         test('every API response should include Vary: Origin', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`, {
                 headers: {
                     Accept: 'application/json',
                     Origin: allowedOrigin,
@@ -115,7 +115,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('Vary: Origin should be present even without Origin header', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`, {
                 headers: {
                     Accept: 'application/json',
                     // No Origin header
@@ -130,7 +130,7 @@ test.describe('CORS Headers', () => {
 
     test.describe('CORS for allowed origins', () => {
         test('should include CORS headers in preflight for allowed origin', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/me`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: allowedOrigin,
@@ -145,7 +145,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('regular GET response should include CORS headers for allowed origin', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
                 headers: {
                     Accept: 'application/json',
                     Origin: allowedOrigin,
@@ -162,7 +162,7 @@ test.describe('CORS Headers', () => {
 
     test.describe('CORS for disallowed origins', () => {
         test('should NOT include Access-Control-Allow-Origin for disallowed origin', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
                 headers: {
                     Accept: 'application/json',
                     Origin: TEST_DISALLOWED_ORIGIN,
@@ -177,7 +177,7 @@ test.describe('CORS Headers', () => {
         });
 
         test('should NOT echo wildcard (*) for Access-Control-Allow-Origin', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
                 headers: {
                     Accept: 'application/json',
                     Origin: allowedOrigin,
@@ -193,7 +193,7 @@ test.describe('CORS Headers', () => {
 
     test.describe('Access-Control-Max-Age', () => {
         test('preflight response should include Max-Age', async ({ request }) => {
-            const response = await request.fetch(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.fetch(`${API_BASE_URL}/api/auth/csrf`, {
                 method: 'OPTIONS',
                 headers: {
                     Origin: allowedOrigin,

--- a/apps/client-e2e/src/api/api-csrf.spec.ts
+++ b/apps/client-e2e/src/api/api-csrf.spec.ts
@@ -4,7 +4,6 @@ import {
     apiPost,
     getCsrfToken,
     ALLOWED_ORIGINS,
-    EchoResponse,
 } from './api-test-helpers';
 
 /**
@@ -15,57 +14,50 @@ import {
  * - POST requests require valid CSRF token
  * - Invalid/missing CSRF token returns 403
  * - Valid CSRF token allows request
+ *
+ * Uses POST /api/auth/logout for testing as it:
+ * - Requires CSRF token (state-changing)
+ * - Works without valid credentials (idempotent for guest)
  */
 
 test.describe('CSRF Protection', () => {
     // Use first allowed origin for tests
     const allowedOrigin = ALLOWED_ORIGINS[0];
 
-    test.describe('POST /api/test/echo (state-changing endpoint)', () => {
+    test.describe('POST /api/auth/logout (state-changing endpoint)', () => {
         test('should reject POST without CSRF token', async ({ request }) => {
-            const { response, body } = await apiPost(request, '/api/test/echo', {
-                data: { test: 'data' },
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
                 origin: allowedOrigin, // Valid origin, but no CSRF
             });
 
             expect(response.status()).toBe(403);
             expect(body.success).toBe(false);
-            // Backend returns generic CSRF_VALIDATION_FAILED for all CSRF errors
             expect(body.errorCode).toBe('CSRF_VALIDATION_FAILED');
         });
 
         test('should reject POST with invalid CSRF token', async ({ request }) => {
-            const { response, body } = await apiPost(request, '/api/test/echo', {
-                data: { test: 'data' },
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
                 origin: allowedOrigin,
                 csrfToken: 'invalid-token-12345',
             });
 
             expect(response.status()).toBe(403);
             expect(body.success).toBe(false);
-            // Backend returns generic CSRF_VALIDATION_FAILED for all CSRF errors
             expect(body.errorCode).toBe('CSRF_VALIDATION_FAILED');
         });
 
         test('should accept POST with valid CSRF token', async ({ request }) => {
             // First, get a valid CSRF token
             const csrfToken = await getCsrfToken(request);
-            const testData = { test: 'data', message: 'hello' };
 
             // Then make POST with valid token
-            const { response, body } = await apiPost<EchoResponse<typeof testData>>(
-                request,
-                '/api/test/echo',
-                {
-                    data: testData,
-                    origin: allowedOrigin,
-                    csrfToken,
-                }
-            );
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
+                origin: allowedOrigin,
+                csrfToken,
+            });
 
             expect(response.status()).toBe(200);
             expect(body.success).toBe(true);
-            expect(body.data?.received).toEqual(testData);
         });
 
         test('should accept X-XSRF-TOKEN header (Angular compatibility)', async ({ request }) => {
@@ -73,14 +65,13 @@ test.describe('CSRF Protection', () => {
             const csrfToken = await getCsrfToken(request);
 
             // Use X-XSRF-TOKEN instead of X-CSRF-Token
-            const response = await request.post(`${API_BASE_URL}/api/test/echo`, {
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
                     Origin: allowedOrigin,
                     'X-XSRF-TOKEN': csrfToken,
                 },
-                data: { angular: true },
             });
 
             const body = await response.json();
@@ -91,20 +82,8 @@ test.describe('CSRF Protection', () => {
     });
 
     test.describe('GET requests (read-only)', () => {
-        test('GET /api/test/ping should work without CSRF token', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
-                headers: {
-                    Accept: 'application/json',
-                },
-            });
-
-            expect(response.status()).toBe(200);
-            const body = await response.json();
-            expect(body.success).toBe(true);
-        });
-
-        test('GET /api/test/csrf should work without CSRF token', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/csrf`, {
+        test('GET /api/auth/csrf should work without CSRF token', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/csrf`, {
                 headers: {
                     Accept: 'application/json',
                 },
@@ -114,6 +93,18 @@ test.describe('CSRF Protection', () => {
             const body = await response.json();
             expect(body.success).toBe(true);
             expect(body.data).toHaveProperty('csrfToken');
+        });
+
+        test('GET /api/auth/me should work without CSRF token', async ({ request }) => {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+
+            expect(response.status()).toBe(200);
+            const body = await response.json();
+            expect(body.success).toBe(true);
         });
     });
 
@@ -132,6 +123,38 @@ test.describe('CSRF Protection', () => {
             expect(token.length).toBeGreaterThanOrEqual(64);
             // Should be hex string
             expect(token).toMatch(/^[a-f0-9]+$/i);
+        });
+    });
+
+    test.describe('CSRF for login endpoint', () => {
+        test('POST /api/auth/login should reject without CSRF token', async ({ request }) => {
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'test', password: 'test' },
+                origin: allowedOrigin,
+                // No CSRF token
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('CSRF_VALIDATION_FAILED');
+        });
+
+        test('POST /api/auth/login should accept with valid CSRF token', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'nonexistent', password: 'wrong' },
+                origin: allowedOrigin,
+                csrfToken,
+            });
+
+            // Should not be CSRF error - will be 401 for invalid credentials
+            if (response.status() === 403) {
+                expect(body.errorCode).not.toBe('CSRF_VALIDATION_FAILED');
+            } else {
+                expect(response.status()).toBe(401);
+                expect(body.errorCode).toBe('INVALID_CREDENTIALS');
+            }
         });
     });
 });

--- a/apps/client-e2e/src/api/api-origin.spec.ts
+++ b/apps/client-e2e/src/api/api-origin.spec.ts
@@ -20,25 +20,29 @@ import {
  * NOTE: Allowed origins depend on server configuration:
  * - Dev: localhost:4200, localhost:4000
  * - Prod: https://new.drevo-info.ru
+ *
+ * Uses POST /api/auth/logout for testing as it:
+ * - Requires Origin validation (state-changing)
+ * - Works without valid credentials (idempotent for guest)
  */
 
 test.describe('Origin/Referer Validation', () => {
     // Use first allowed origin for tests
     const allowedOrigin = ALLOWED_ORIGINS[0];
+
     test.describe('POST without Origin/Referer', () => {
         test('should reject POST without Origin and Referer headers', async ({ request }) => {
             // Get CSRF token first
             const csrfToken = await getCsrfToken(request);
 
             // POST without Origin or Referer
-            const response = await request.post(`${API_BASE_URL}/api/test/echo`, {
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
                     'X-CSRF-Token': csrfToken,
                     // No Origin, no Referer
                 },
-                data: { test: 'data' },
             });
 
             const body = await response.json();
@@ -53,8 +57,7 @@ test.describe('Origin/Referer Validation', () => {
         test('should reject POST from disallowed origin', async ({ request }) => {
             const csrfToken = await getCsrfToken(request);
 
-            const { response, body } = await apiPost(request, '/api/test/echo', {
-                data: { test: 'data' },
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
                 origin: TEST_DISALLOWED_ORIGIN,
                 csrfToken,
             });
@@ -67,8 +70,7 @@ test.describe('Origin/Referer Validation', () => {
         test('should reject POST from random origin', async ({ request }) => {
             const csrfToken = await getCsrfToken(request);
 
-            const { response, body } = await apiPost(request, '/api/test/echo', {
-                data: { test: 'data' },
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
                 origin: 'https://attacker-site.com',
                 csrfToken,
             });
@@ -84,8 +86,7 @@ test.describe('Origin/Referer Validation', () => {
             const csrfToken = await getCsrfToken(request);
 
             // Use configured allowed origin
-            const { response, body } = await apiPost(request, '/api/test/echo', {
-                data: { test: 'allowed-origin' },
+            const { response, body } = await apiPost(request, '/api/auth/logout', {
                 origin: allowedOrigin,
                 csrfToken,
             });
@@ -102,7 +103,7 @@ test.describe('Origin/Referer Validation', () => {
             // Parse allowed origin to use as Referer
             const refererUrl = new URL(allowedOrigin);
 
-            const response = await request.post(`${API_BASE_URL}/api/test/echo`, {
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -110,7 +111,6 @@ test.describe('Origin/Referer Validation', () => {
                     Referer: `${refererUrl.origin}/some/page`,
                     // No Origin header
                 },
-                data: { test: 'referer-only' },
             });
 
             const body = await response.json();
@@ -122,7 +122,7 @@ test.describe('Origin/Referer Validation', () => {
         test('should reject POST with invalid Referer when Origin is missing', async ({ request }) => {
             const csrfToken = await getCsrfToken(request);
 
-            const response = await request.post(`${API_BASE_URL}/api/test/echo`, {
+            const response = await request.post(`${API_BASE_URL}/api/auth/logout`, {
                 headers: {
                     'Content-Type': 'application/json',
                     Accept: 'application/json',
@@ -130,7 +130,6 @@ test.describe('Origin/Referer Validation', () => {
                     Referer: 'https://evil-site.com/attack',
                     // No Origin header
                 },
-                data: { test: 'invalid-referer' },
             });
 
             const body = await response.json();
@@ -143,7 +142,7 @@ test.describe('Origin/Referer Validation', () => {
 
     test.describe('GET requests (no Origin validation)', () => {
         test('GET should work without Origin header', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
                 headers: {
                     Accept: 'application/json',
                     // No Origin
@@ -156,7 +155,7 @@ test.describe('Origin/Referer Validation', () => {
         });
 
         test('GET should work with any Origin header', async ({ request }) => {
-            const response = await request.get(`${API_BASE_URL}/api/test/ping`, {
+            const response = await request.get(`${API_BASE_URL}/api/auth/me`, {
                 headers: {
                     Accept: 'application/json',
                     Origin: 'https://any-origin.com',
@@ -166,6 +165,42 @@ test.describe('Origin/Referer Validation', () => {
             expect(response.status()).toBe(200);
             const body = await response.json();
             expect(body.success).toBe(true);
+        });
+    });
+
+    test.describe('Login endpoint Origin validation', () => {
+        test('POST /api/auth/login should reject without Origin', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const response = await request.post(`${API_BASE_URL}/api/auth/login`, {
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-CSRF-Token': csrfToken,
+                    // No Origin, no Referer
+                },
+                data: { username: 'test', password: 'test' },
+            });
+
+            const body = await response.json();
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_REQUIRED');
+        });
+
+        test('POST /api/auth/login should reject from disallowed Origin', async ({ request }) => {
+            const csrfToken = await getCsrfToken(request);
+
+            const { response, body } = await apiPost(request, '/api/auth/login', {
+                data: { username: 'test', password: 'test' },
+                origin: TEST_DISALLOWED_ORIGIN,
+                csrfToken,
+            });
+
+            expect(response.status()).toBe(403);
+            expect(body.success).toBe(false);
+            expect(body.errorCode).toBe('ORIGIN_NOT_ALLOWED');
         });
     });
 });

--- a/apps/client-e2e/src/api/api-test-helpers.ts
+++ b/apps/client-e2e/src/api/api-test-helpers.ts
@@ -24,11 +24,46 @@ export interface CsrfResponse {
 }
 
 /**
- * Echo endpoint response - wraps input data in 'received' property
- * Used by POST /api/test/echo
+ * Auth me response
  */
-export interface EchoResponse<T = Record<string, unknown>> {
-    received: T;
+export interface AuthMeResponse {
+    isAuthenticated: boolean;
+    user?: {
+        login: string;
+        name?: string;
+        email?: string;
+        role?: string;
+        permissions?: {
+            canEdit: boolean;
+            canModerate: boolean;
+            canAdmin: boolean;
+        };
+    };
+}
+
+/**
+ * Login response
+ */
+export interface LoginResponse {
+    user: {
+        login: string;
+        name?: string;
+        email?: string;
+        role?: string;
+        permissions?: {
+            canEdit: boolean;
+            canModerate: boolean;
+            canAdmin: boolean;
+        };
+    };
+    csrfToken: string;
+}
+
+/**
+ * Logout response
+ */
+export interface LogoutResponse {
+    message: string;
 }
 
 /**
@@ -100,23 +135,9 @@ export async function apiPost<T>(
 }
 
 /**
- * Helper to get CSRF token from test endpoint
+ * Helper to get CSRF token from auth endpoint
  */
 export async function getCsrfToken(request: APIRequestContext): Promise<string> {
-    const { response, body } = await apiGet<CsrfResponse>(request, '/api/test/csrf');
-    expect(response.status()).toBe(200);
-    expect(body.success).toBe(true);
-
-    if (!body.data || !body.data.csrfToken) {
-        throw new Error('CSRF token is missing in the API response');
-    }
-    return body.data.csrfToken;
-}
-
-/**
- * Helper to get CSRF token from auth endpoint (for auth tests)
- */
-export async function getAuthCsrfToken(request: APIRequestContext): Promise<string> {
     const { response, body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
     expect(response.status()).toBe(200);
     expect(body.success).toBe(true);

--- a/apps/client-e2e/src/api/api-test-helpers.ts
+++ b/apps/client-e2e/src/api/api-test-helpers.ts
@@ -100,10 +100,24 @@ export async function apiPost<T>(
 }
 
 /**
- * Helper to get CSRF token
+ * Helper to get CSRF token from test endpoint
  */
 export async function getCsrfToken(request: APIRequestContext): Promise<string> {
     const { response, body } = await apiGet<CsrfResponse>(request, '/api/test/csrf');
+    expect(response.status()).toBe(200);
+    expect(body.success).toBe(true);
+
+    if (!body.data || !body.data.csrfToken) {
+        throw new Error('CSRF token is missing in the API response');
+    }
+    return body.data.csrfToken;
+}
+
+/**
+ * Helper to get CSRF token from auth endpoint (for auth tests)
+ */
+export async function getAuthCsrfToken(request: APIRequestContext): Promise<string> {
+    const { response, body } = await apiGet<CsrfResponse>(request, '/api/auth/csrf');
     expect(response.status()).toBe(200);
     expect(body.success).toBe(true);
 


### PR DESCRIPTION
- Added tests for `/api/auth/csrf`, `/api/auth/me`, `/api/auth/login`, and `/api/auth/logout`.
- Verified CSRF token handling, security headers, origin validation, and session management.
- Introduced `AuthMeResponse`, `CsrfResponse`, and `LoginResponse` typings for API responses.
- Enhanced `api-test-helpers` with new `getAuthCsrfToken` utility.