### PR TITLE
style: add custom scrollbar styles for overlay components

### DIFF
--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -90,22 +90,20 @@ html.dark-theme body {
 // SCROLLBAR STYLES
 // ============================================================================
 
-/* Firefox + современные браузеры */
-.cdk-virtual-scrollable,
+/* Firefox + modern browsers */
+.cdk-virtual-scroll-viewport,
 .cdk-overlay-container .mat-mdc-select-panel,
-.cdk-virtual-scrollable,
 .cdk-overlay-container .mat-mdc-autocomplete-panel {
     scrollbar-width: thin;
     scrollbar-color: rgba(0, 0, 0, 0.45) transparent;
 }
 
 /* Chromium/Safari (non-standard) */
-.cdk-virtual-scrollable,
 .cdk-overlay-container .mat-mdc-select-panel::-webkit-scrollbar,
-.cdk-virtual-scrollable,
 .cdk-overlay-container .mat-mdc-autocomplete-panel::-webkit-scrollbar {
     width: 10px;
 }
+
 .cdk-overlay-container .mat-mdc-select-panel::-webkit-scrollbar-thumb,
 .cdk-overlay-container .mat-mdc-autocomplete-panel::-webkit-scrollbar-thumb {
     border-radius: 999px;

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -85,3 +85,28 @@ html.dark-theme body {
     background-color: var(--themed-search-highlighted-bg);
     color: var(--themed-search-highlighted);
 }
+
+// ============================================================================
+// SCROLLBAR STYLES
+// ============================================================================
+
+/* Firefox + современные браузеры */
+.cdk-virtual-scrollable,
+.cdk-overlay-container .mat-mdc-select-panel,
+.cdk-virtual-scrollable,
+.cdk-overlay-container .mat-mdc-autocomplete-panel {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.45) transparent;
+}
+
+/* Chromium/Safari (non-standard) */
+.cdk-virtual-scrollable,
+.cdk-overlay-container .mat-mdc-select-panel::-webkit-scrollbar,
+.cdk-virtual-scrollable,
+.cdk-overlay-container .mat-mdc-autocomplete-panel::-webkit-scrollbar {
+    width: 10px;
+}
+.cdk-overlay-container .mat-mdc-select-panel::-webkit-scrollbar-thumb,
+.cdk-overlay-container .mat-mdc-autocomplete-panel::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+}

--- a/apps/client/src/styles.scss
+++ b/apps/client/src/styles.scss
@@ -91,11 +91,11 @@ html.dark-theme body {
 // ============================================================================
 
 /* Firefox + modern browsers */
-.cdk-virtual-scroll-viewport,
+.cdk-virtual-scrollable,
 .cdk-overlay-container .mat-mdc-select-panel,
 .cdk-overlay-container .mat-mdc-autocomplete-panel {
     scrollbar-width: thin;
-    scrollbar-color: rgba(0, 0, 0, 0.45) transparent;
+    scrollbar-color: var(--themed-border-color) transparent;
 }
 
 /* Chromium/Safari (non-standard) */


### PR DESCRIPTION
- Applied consistent scrollbar styles across modern browsers (Firefox, Chromium, and Safari).
- Updated styles for `cdk-virtual-scrollable` and overlay panels of select and autocomplete components.