### PR TITLE
feat(search): support empty and optional queries for fetching all art…

### DIFF
--- a/apps/client/src/app/pages/search/search.component.spec.ts
+++ b/apps/client/src/app/pages/search/search.component.spec.ts
@@ -54,8 +54,18 @@ describe('SearchComponent', () => {
         expect(spectator.component.searchQuery()).toBe('test query');
     });
 
+    it('should load initial results on component creation', () => {
+        spectator = createComponent();
+
+        expect(mockArticleService.searchArticles).toHaveBeenCalledWith({
+            query: '',
+            page: 1,
+        });
+    });
+
     it('should call articleService.searchArticles after debounce time', () => {
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('angular');
 
@@ -69,50 +79,79 @@ describe('SearchComponent', () => {
         });
     });
 
-    it('should not call articleService.searchArticles when search query is empty', () => {
+    it('should call articleService.searchArticles with empty query when search field is cleared', () => {
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('');
 
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
-        expect(mockArticleService.searchArticles).not.toHaveBeenCalled();
+        expect(mockArticleService.searchArticles).toHaveBeenCalledWith({
+            query: '',
+            page: 1,
+        });
     });
 
-    it('should not call articleService.searchArticles when search query is only whitespace', () => {
+    it('should call articleService.searchArticles when search query is whitespace', () => {
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('   ');
 
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
-        expect(mockArticleService.searchArticles).not.toHaveBeenCalled();
+        expect(mockArticleService.searchArticles).toHaveBeenCalledWith({
+            query: '   ',
+            page: 1,
+        });
     });
 
-    it('should clear results when search query becomes empty after debounce', () => {
-        mockArticleService.searchArticles.mockReturnValue(
-            of({
-                items: [{ id: 1, title: 'Test Article' }],
-                total: 1,
-                page: 1,
-                pageSize: 25,
-                totalPages: 1,
-            })
-        );
+    it('should reload all results when search query becomes empty after debounce', () => {
+        const searchResponse = {
+            items: [{ id: 1, title: 'Test Article' }],
+            total: 1,
+            page: 1,
+            pageSize: 25,
+            totalPages: 1,
+        };
+        const allArticlesResponse = {
+            items: [
+                { id: 1, title: 'Article 1' },
+                { id: 2, title: 'Article 2' },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 25,
+            totalPages: 1,
+        };
+        mockArticleService.searchArticles
+            .mockReturnValueOnce(of(allArticlesResponse)) // initial load
+            .mockReturnValueOnce(of(searchResponse)) // search for 'test'
+            .mockReturnValueOnce(of(allArticlesResponse)); // clear search
+
         spectator = createComponent();
+        expect(spectator.component.searchResults().length).toBe(2);
 
         spectator.component.onSearchChange('test');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
         expect(spectator.component.searchResults().length).toBe(1);
 
         spectator.component.onSearchChange('');
-        // Results clear after debounce when using switchMap for cancellation
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
-        expect(spectator.component.searchResults().length).toBe(0);
-        expect(spectator.component.totalResults()).toBe(0);
+        // Results reload with all articles
+        expect(spectator.component.searchResults().length).toBe(2);
+        expect(spectator.component.totalResults()).toBe(2);
     });
 
     it('should update searchResults and totalResults on successful search', () => {
+        const initialResponse = {
+            items: [],
+            total: 0,
+            page: 1,
+            pageSize: 25,
+            totalPages: 0,
+        };
         const mockResponse = {
             items: [
                 { id: 1, title: 'Article 1' },
@@ -123,7 +162,9 @@ describe('SearchComponent', () => {
             pageSize: 25,
             totalPages: 2,
         };
-        mockArticleService.searchArticles.mockReturnValue(of(mockResponse));
+        mockArticleService.searchArticles
+            .mockReturnValueOnce(of(initialResponse)) // initial load
+            .mockReturnValueOnce(of(mockResponse));
         spectator = createComponent();
 
         spectator.component.onSearchChange('test');
@@ -136,6 +177,7 @@ describe('SearchComponent', () => {
 
     it('should debounce multiple rapid search inputs', () => {
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('a');
         jest.advanceTimersByTime(100);
@@ -162,6 +204,7 @@ describe('SearchComponent', () => {
 
     it('should not call search again if query has not changed', () => {
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('test');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
@@ -173,9 +216,9 @@ describe('SearchComponent', () => {
     });
 
     it('should handle search errors gracefully', () => {
-        mockArticleService.searchArticles.mockReturnValue(
-            throwError(() => new Error('Search failed'))
-        );
+        mockArticleService.searchArticles
+            .mockReturnValueOnce(of({ items: [], total: 0, page: 1, pageSize: 25, totalPages: 0 })) // initial load
+            .mockReturnValueOnce(throwError(() => new Error('Search failed'))); // search error
         spectator = createComponent();
 
         spectator.component.onSearchChange('test');
@@ -186,8 +229,15 @@ describe('SearchComponent', () => {
         expect(spectator.component.isLoading()).toBe(false);
     });
 
-    it('should cancel previous request when clearing search quickly (race condition)', () => {
+    it('should cancel previous search request when clearing search quickly (race condition)', () => {
         // Simulate a slow HTTP request that takes 1000ms
+        const initialResponse = {
+            items: [{ id: 0, title: 'Initial' }],
+            total: 1,
+            page: 1,
+            pageSize: 25,
+            totalPages: 1,
+        };
         const slowResponse = {
             items: [{ id: 1, title: 'Stale Result' }],
             total: 1,
@@ -195,10 +245,28 @@ describe('SearchComponent', () => {
             pageSize: 25,
             totalPages: 1,
         };
-        mockArticleService.searchArticles.mockReturnValue(
-            of(slowResponse).pipe(delay(1000))
-        );
+        const emptyQueryResponse = {
+            items: [
+                { id: 2, title: 'All Articles 1' },
+                { id: 3, title: 'All Articles 2' },
+            ],
+            total: 2,
+            page: 1,
+            pageSize: 25,
+            totalPages: 1,
+        };
+        mockArticleService.searchArticles
+            .mockReturnValueOnce(of(initialResponse)) // initial load
+            .mockReturnValueOnce(of(slowResponse).pipe(delay(1000))) // slow search
+            .mockReturnValueOnce(of(emptyQueryResponse).pipe(delay(50))); // clear search
+
         spectator = createComponent();
+        mockArticleService.searchArticles.mockClear();
+
+        // Set up mock for search requests
+        mockArticleService.searchArticles
+            .mockReturnValueOnce(of(slowResponse).pipe(delay(1000)))
+            .mockReturnValueOnce(of(emptyQueryResponse).pipe(delay(50)));
 
         // User types 'a'
         spectator.component.onSearchChange('a');
@@ -215,16 +283,22 @@ describe('SearchComponent', () => {
         spectator.component.onSearchChange('');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
-        // Results should be empty, loading should be false
-        expect(spectator.component.searchResults()).toEqual([]);
+        // Wait for the clear request to complete
+        jest.advanceTimersByTime(50);
+
+        // Results should be the all articles response
+        expect(spectator.component.searchResults()).toEqual(
+            emptyQueryResponse.items
+        );
         expect(spectator.component.isLoading()).toBe(false);
 
         // Now let the slow request "complete" - it should have been cancelled
         jest.advanceTimersByTime(1000);
 
-        // Results should still be empty - stale response should not appear
-        expect(spectator.component.searchResults()).toEqual([]);
-        expect(spectator.component.totalResults()).toBe(0);
+        // Results should still be the all articles - stale response was cancelled
+        expect(spectator.component.searchResults()).toEqual(
+            emptyQueryResponse.items
+        );
     });
 
     it('should cancel previous request when typing new query quickly', () => {
@@ -243,7 +317,10 @@ describe('SearchComponent', () => {
             totalPages: 1,
         };
 
+        // Setup: initial load completes, then search mocks
+        mockArticleService.searchArticles.mockReset();
         mockArticleService.searchArticles
+            .mockReturnValueOnce(of({ items: [], total: 0, page: 1, pageSize: 25, totalPages: 0 })) // initial load
             .mockReturnValueOnce(of(staleResponse).pipe(delay(1000)))
             .mockReturnValueOnce(of(freshResponse).pipe(delay(100)));
 
@@ -252,12 +329,12 @@ describe('SearchComponent', () => {
         // User types 'a'
         spectator.component.onSearchChange('a');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
-        expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(1);
+        expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(2); // initial + 'a'
 
         // User types 'abc' before first request completes
         spectator.component.onSearchChange('abc');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
-        expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(2);
+        expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(3); // + 'abc'
 
         // Wait for second (faster) request to complete
         jest.advanceTimersByTime(100);
@@ -299,13 +376,23 @@ describe('SearchComponent', () => {
             totalPages: 2,
         };
 
+        const emptyInitialResponse = {
+            items: [],
+            total: 0,
+            page: 1,
+            pageSize: 25,
+            totalPages: 0,
+        };
+
         it('should load next page and append results to existing ones', () => {
+            mockArticleService.searchArticles.mockReset();
             mockArticleService.searchArticles
-                .mockReturnValueOnce(of(firstPageResponse))
-                .mockReturnValueOnce(of(secondPageResponse));
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(firstPageResponse)) // search
+                .mockReturnValueOnce(of(secondPageResponse)); // load more
             spectator = createComponent();
 
-            // Load first page
+            // Load first page via search
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
@@ -337,32 +424,35 @@ describe('SearchComponent', () => {
                 pageSize: 25,
                 totalPages: 1,
             };
-            mockArticleService.searchArticles.mockReturnValue(
-                of(allLoadedResponse)
-            );
+            mockArticleService.searchArticles.mockReset();
+            mockArticleService.searchArticles
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(allLoadedResponse)); // search
             spectator = createComponent();
 
             // Load first (and only) page
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
-            expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(1);
+            expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(2); // initial + search
 
             // Try to load more
             spectator.component.onLoadMore();
 
-            // Should not call searchArticles again
-            expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(1);
+            // Should not call searchArticles again since all results are loaded
+            expect(mockArticleService.searchArticles).toHaveBeenCalledTimes(2);
             expect(spectator.component.isLoadingMore()).toBe(false);
         });
 
         it('should set isLoadingMore to true during request', () => {
+            mockArticleService.searchArticles.mockReset();
             mockArticleService.searchArticles
-                .mockReturnValueOnce(of(firstPageResponse))
-                .mockReturnValueOnce(of(secondPageResponse).pipe(delay(500)));
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(firstPageResponse)) // search
+                .mockReturnValueOnce(of(secondPageResponse).pipe(delay(500))); // load more (delayed)
             spectator = createComponent();
 
-            // Load first page
+            // Load first page via search
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
@@ -378,14 +468,14 @@ describe('SearchComponent', () => {
         });
 
         it('should handle pagination errors without losing existing results', () => {
+            mockArticleService.searchArticles.mockReset();
             mockArticleService.searchArticles
-                .mockReturnValueOnce(of(firstPageResponse))
-                .mockReturnValueOnce(
-                    throwError(() => new Error('Pagination failed'))
-                );
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(firstPageResponse)) // search
+                .mockReturnValueOnce(throwError(() => new Error('Pagination failed'))); // load more error
             spectator = createComponent();
 
-            // Load first page
+            // Load first page via search
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
@@ -401,14 +491,14 @@ describe('SearchComponent', () => {
         });
 
         it('should not increment currentPage on error', () => {
+            mockArticleService.searchArticles.mockReset();
             mockArticleService.searchArticles
-                .mockReturnValueOnce(of(firstPageResponse))
-                .mockReturnValueOnce(
-                    throwError(() => new Error('Pagination failed'))
-                );
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(firstPageResponse)) // search
+                .mockReturnValueOnce(throwError(() => new Error('Pagination failed'))); // load more error
             spectator = createComponent();
 
-            // Load first page
+            // Load first page via search
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
@@ -422,13 +512,15 @@ describe('SearchComponent', () => {
         });
 
         it('should reset to page 1 when starting a new search', () => {
+            mockArticleService.searchArticles.mockReset();
             mockArticleService.searchArticles
-                .mockReturnValueOnce(of(firstPageResponse))
-                .mockReturnValueOnce(of(secondPageResponse))
-                .mockReturnValueOnce(of(firstPageResponse));
+                .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
+                .mockReturnValueOnce(of(firstPageResponse)) // first search
+                .mockReturnValueOnce(of(secondPageResponse)) // load more
+                .mockReturnValueOnce(of(firstPageResponse)); // new search
             spectator = createComponent();
 
-            // Load first page
+            // Load first page via search
             spectator.component.onSearchChange('test');
             jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 

--- a/apps/client/src/app/pages/search/search.component.spec.ts
+++ b/apps/client/src/app/pages/search/search.component.spec.ts
@@ -54,8 +54,13 @@ describe('SearchComponent', () => {
         expect(spectator.component.searchQuery()).toBe('test query');
     });
 
-    it('should load initial results on component creation', () => {
+    it('should load initial results on component creation after debounce', () => {
         spectator = createComponent();
+
+        // Initial load happens after debounce due to startWith('')
+        expect(mockArticleService.searchArticles).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
         expect(mockArticleService.searchArticles).toHaveBeenCalledWith({
             query: '',
@@ -93,18 +98,17 @@ describe('SearchComponent', () => {
         });
     });
 
-    it('should call articleService.searchArticles when search query is whitespace', () => {
+    it('should trim whitespace from search query before calling service', () => {
         spectator = createComponent();
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
         mockArticleService.searchArticles.mockClear();
 
         spectator.component.onSearchChange('   ');
 
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
 
-        expect(mockArticleService.searchArticles).toHaveBeenCalledWith({
-            query: '   ',
-            page: 1,
-        });
+        // Query is trimmed, so '   ' becomes '' which is same as initial - no new call due to distinctUntilChanged
+        expect(mockArticleService.searchArticles).not.toHaveBeenCalled();
     });
 
     it('should reload all results when search query becomes empty after debounce', () => {
@@ -131,6 +135,7 @@ describe('SearchComponent', () => {
             .mockReturnValueOnce(of(allArticlesResponse)); // clear search
 
         spectator = createComponent();
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
         expect(spectator.component.searchResults().length).toBe(2);
 
         spectator.component.onSearchChange('test');
@@ -166,6 +171,7 @@ describe('SearchComponent', () => {
             .mockReturnValueOnce(of(initialResponse)) // initial load
             .mockReturnValueOnce(of(mockResponse));
         spectator = createComponent();
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
         spectator.component.onSearchChange('test');
         jest.advanceTimersByTime(DEBOUNCE_TIME_MS);
@@ -217,7 +223,15 @@ describe('SearchComponent', () => {
 
     it('should handle search errors gracefully', () => {
         mockArticleService.searchArticles
-            .mockReturnValueOnce(of({ items: [], total: 0, page: 1, pageSize: 25, totalPages: 0 })) // initial load
+            .mockReturnValueOnce(
+                of({
+                    items: [],
+                    total: 0,
+                    page: 1,
+                    pageSize: 25,
+                    totalPages: 0,
+                })
+            ) // initial load
             .mockReturnValueOnce(throwError(() => new Error('Search failed'))); // search error
         spectator = createComponent();
 
@@ -255,18 +269,14 @@ describe('SearchComponent', () => {
             pageSize: 25,
             totalPages: 1,
         };
+        mockArticleService.searchArticles.mockReset();
         mockArticleService.searchArticles
             .mockReturnValueOnce(of(initialResponse)) // initial load
-            .mockReturnValueOnce(of(slowResponse).pipe(delay(1000))) // slow search
-            .mockReturnValueOnce(of(emptyQueryResponse).pipe(delay(50))); // clear search
+            .mockReturnValueOnce(of(slowResponse).pipe(delay(1000))) // slow search 'a'
+            .mockReturnValueOnce(of(emptyQueryResponse).pipe(delay(50))); // clear search ''
 
         spectator = createComponent();
-        mockArticleService.searchArticles.mockClear();
-
-        // Set up mock for search requests
-        mockArticleService.searchArticles
-            .mockReturnValueOnce(of(slowResponse).pipe(delay(1000)))
-            .mockReturnValueOnce(of(emptyQueryResponse).pipe(delay(50)));
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
         // User types 'a'
         spectator.component.onSearchChange('a');
@@ -320,11 +330,20 @@ describe('SearchComponent', () => {
         // Setup: initial load completes, then search mocks
         mockArticleService.searchArticles.mockReset();
         mockArticleService.searchArticles
-            .mockReturnValueOnce(of({ items: [], total: 0, page: 1, pageSize: 25, totalPages: 0 })) // initial load
+            .mockReturnValueOnce(
+                of({
+                    items: [],
+                    total: 0,
+                    page: 1,
+                    pageSize: 25,
+                    totalPages: 0,
+                })
+            ) // initial load
             .mockReturnValueOnce(of(staleResponse).pipe(delay(1000)))
             .mockReturnValueOnce(of(freshResponse).pipe(delay(100)));
 
         spectator = createComponent();
+        jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
         // User types 'a'
         spectator.component.onSearchChange('a');
@@ -391,6 +410,7 @@ describe('SearchComponent', () => {
                 .mockReturnValueOnce(of(firstPageResponse)) // search
                 .mockReturnValueOnce(of(secondPageResponse)); // load more
             spectator = createComponent();
+            jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
             // Load first page via search
             spectator.component.onSearchChange('test');
@@ -429,6 +449,7 @@ describe('SearchComponent', () => {
                 .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
                 .mockReturnValueOnce(of(allLoadedResponse)); // search
             spectator = createComponent();
+            jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
             // Load first (and only) page
             spectator.component.onSearchChange('test');
@@ -451,6 +472,7 @@ describe('SearchComponent', () => {
                 .mockReturnValueOnce(of(firstPageResponse)) // search
                 .mockReturnValueOnce(of(secondPageResponse).pipe(delay(500))); // load more (delayed)
             spectator = createComponent();
+            jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
             // Load first page via search
             spectator.component.onSearchChange('test');
@@ -472,8 +494,11 @@ describe('SearchComponent', () => {
             mockArticleService.searchArticles
                 .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
                 .mockReturnValueOnce(of(firstPageResponse)) // search
-                .mockReturnValueOnce(throwError(() => new Error('Pagination failed'))); // load more error
+                .mockReturnValueOnce(
+                    throwError(() => new Error('Pagination failed'))
+                ); // load more error
             spectator = createComponent();
+            jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
             // Load first page via search
             spectator.component.onSearchChange('test');
@@ -486,7 +511,9 @@ describe('SearchComponent', () => {
             spectator.component.onLoadMore();
 
             // Existing results should be preserved
-            expect(spectator.component.searchResults()).toEqual(existingResults);
+            expect(spectator.component.searchResults()).toEqual(
+                existingResults
+            );
             expect(spectator.component.isLoadingMore()).toBe(false);
         });
 
@@ -495,7 +522,9 @@ describe('SearchComponent', () => {
             mockArticleService.searchArticles
                 .mockReturnValueOnce(of(emptyInitialResponse)) // initial load
                 .mockReturnValueOnce(of(firstPageResponse)) // search
-                .mockReturnValueOnce(throwError(() => new Error('Pagination failed'))); // load more error
+                .mockReturnValueOnce(
+                    throwError(() => new Error('Pagination failed'))
+                ); // load more error
             spectator = createComponent();
 
             // Load first page via search
@@ -519,6 +548,7 @@ describe('SearchComponent', () => {
                 .mockReturnValueOnce(of(secondPageResponse)) // load more
                 .mockReturnValueOnce(of(firstPageResponse)); // new search
             spectator = createComponent();
+            jest.advanceTimersByTime(DEBOUNCE_TIME_MS); // wait for initial load
 
             // Load first page via search
             spectator.component.onSearchChange('test');

--- a/apps/client/src/app/pages/search/search.component.ts
+++ b/apps/client/src/app/pages/search/search.component.ts
@@ -21,7 +21,6 @@ import { ArticleSearchResult } from '@drevo-web/shared';
 import {
     debounceTime,
     distinctUntilChanged,
-    EMPTY,
     Subject,
     switchMap,
     tap,
@@ -64,29 +63,25 @@ export class SearchComponent implements OnInit {
         () =>
             this.searchQuery().length > 0 &&
             !this.isLoading() &&
-            !this.hasResults()
+            this.totalResults() === 0 &&
+            this.searchResults().length === 0
     );
 
     readonly trackByFn = (_index: number, item: ArticleSearchResult): number =>
         item.id;
 
     ngOnInit(): void {
+        // Load initial results without search query
+        this.loadArticles('');
+
         this.searchSubject
             .pipe(
                 debounceTime(DEBOUNCE_TIME_MS),
                 distinctUntilChanged(),
-                tap(query => {
-                    if (query.trim().length === 0) {
-                        this.searchResults.set([]);
-                        this.totalResults.set(0);
-                        this.isLoading.set(false);
-                    }
+                tap(() => {
                     this.currentPage.set(1);
                 }),
                 switchMap(query => {
-                    if (query.trim().length === 0) {
-                        return EMPTY;
-                    }
                     return this.articleService.searchArticles({
                         query,
                         page: 1,
@@ -108,13 +103,31 @@ export class SearchComponent implements OnInit {
             });
     }
 
+    /**
+     * Load articles with optional query
+     */
+    private loadArticles(query: string): void {
+        this.isLoading.set(true);
+        this.articleService
+            .searchArticles({ query, page: 1 })
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: response => {
+                    this.searchResults.set([...response.items]);
+                    this.totalResults.set(response.total);
+                    this.isLoading.set(false);
+                },
+                error: () => {
+                    this.searchResults.set([]);
+                    this.totalResults.set(0);
+                    this.isLoading.set(false);
+                },
+            });
+    }
+
     onSearchChange(value: string): void {
         this.searchQuery.set(value);
-
-        if (value.trim().length > 0) {
-            this.isLoading.set(true);
-        }
-
+        this.isLoading.set(true);
         this.searchSubject.next(value);
     }
 

--- a/apps/client/src/app/pages/search/search.component.ts
+++ b/apps/client/src/app/pages/search/search.component.ts
@@ -21,6 +21,8 @@ import { ArticleSearchResult } from '@drevo-web/shared';
 import {
     debounceTime,
     distinctUntilChanged,
+    map,
+    startWith,
     Subject,
     switchMap,
     tap,
@@ -71,16 +73,16 @@ export class SearchComponent implements OnInit {
         item.id;
 
     ngOnInit(): void {
-        // Load initial results without search query
-        this.loadArticles('');
-
         this.searchSubject
             .pipe(
-                debounceTime(DEBOUNCE_TIME_MS),
+                startWith(''),
+                map(query => query.trim()),
                 distinctUntilChanged(),
                 tap(() => {
+                    this.isLoading.set(true);
                     this.currentPage.set(1);
                 }),
+                debounceTime(DEBOUNCE_TIME_MS),
                 switchMap(query => {
                     return this.articleService.searchArticles({
                         query,
@@ -103,31 +105,8 @@ export class SearchComponent implements OnInit {
             });
     }
 
-    /**
-     * Load articles with optional query
-     */
-    private loadArticles(query: string): void {
-        this.isLoading.set(true);
-        this.articleService
-            .searchArticles({ query, page: 1 })
-            .pipe(takeUntilDestroyed(this.destroyRef))
-            .subscribe({
-                next: response => {
-                    this.searchResults.set([...response.items]);
-                    this.totalResults.set(response.total);
-                    this.isLoading.set(false);
-                },
-                error: () => {
-                    this.searchResults.set([]);
-                    this.totalResults.set(0);
-                    this.isLoading.set(false);
-                },
-            });
-    }
-
     onSearchChange(value: string): void {
         this.searchQuery.set(value);
-        this.isLoading.set(true);
         this.searchSubject.next(value);
     }
 

--- a/apps/client/src/app/services/articles/article-api.service.spec.ts
+++ b/apps/client/src/app/services/articles/article-api.service.spec.ts
@@ -91,6 +91,34 @@ describe('ArticleApiService', () => {
 
             expectSearchRequest({ page: '3', size: '50' });
         });
+
+        it('should not include q param when query is empty', () => {
+            spectator.service.searchArticles('').subscribe();
+
+            const req = httpController.expectOne(request => {
+                return (
+                    request.url === '/api/articles/search' &&
+                    !request.params.has('q') &&
+                    request.params.get('page') === '1' &&
+                    request.params.get('size') === '25'
+                );
+            });
+            req.flush(createMockResponse());
+        });
+
+        it('should not include q param when query is not provided', () => {
+            spectator.service.searchArticles().subscribe();
+
+            const req = httpController.expectOne(request => {
+                return (
+                    request.url === '/api/articles/search' &&
+                    !request.params.has('q') &&
+                    request.params.get('page') === '1' &&
+                    request.params.get('size') === '25'
+                );
+            });
+            req.flush(createMockResponse());
+        });
     });
 
     describe('error handling', () => {

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -29,20 +29,23 @@ export class ArticleApiService {
     /**
      * Search articles by title
      *
-     * @param query - Search query string
+     * @param query - Search query string (empty string returns all articles)
      * @param page - Page number (1-based)
      * @param pageSize - Number of items per page
      * @returns Observable with raw API response
      */
     searchArticles(
-        query: string,
+        query = '',
         page = 1,
         pageSize = DEFAULT_ARTICLE_SEARCH_PAGE_SIZE
     ): Observable<ArticleSearchResponseApi> {
-        const params = new HttpParams()
-            .set('q', query)
+        let params = new HttpParams()
             .set('page', page.toString())
             .set('size', pageSize.toString());
+
+        if (query) {
+            params = params.set('q', query);
+        }
 
         return this.http
             .get<

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -43,8 +43,9 @@ export class ArticleApiService {
             .set('page', page.toString())
             .set('size', pageSize.toString());
 
-        if (query) {
-            params = params.set('q', query);
+        const trimmedQuery = query.trim();
+        if (trimmedQuery) {
+            params = params.set('q', trimmedQuery);
         }
 
         return this.http

--- a/apps/client/src/app/services/articles/article.service.ts
+++ b/apps/client/src/app/services/articles/article.service.ts
@@ -27,14 +27,14 @@ export class ArticleService {
     /**
      * Search articles by title
      *
-     * @param params - Search parameters
+     * @param params - Search parameters (query is optional - empty returns all articles)
      * @returns Observable with mapped search response
      */
     searchArticles(
-        params: ArticleSearchParams
+        params: ArticleSearchParams = {}
     ): Observable<ArticleSearchResponse> {
         const {
-            query,
+            query = '',
             page = 1,
             pageSize = DEFAULT_ARTICLE_SEARCH_PAGE_SIZE,
         } = params;

--- a/libs/shared/src/lib/models/article-search.ts
+++ b/libs/shared/src/lib/models/article-search.ts
@@ -26,7 +26,7 @@ export interface ArticleSearchResponse {
  * Search parameters for article search
  */
 export interface ArticleSearchParams {
-    readonly query: string;
+    readonly query?: string;
     readonly page?: number;
     readonly pageSize?: number;
 }


### PR DESCRIPTION
…icles

- Allowed `query` to be optional in `ArticleSearchParams`, enabling retrieval of all articles when omitted or empty.
- Updated services to handle cases where `query` is empty or undefined.
- Improved logic for searching and loading results in `SearchComponent`.
- Refined corresponding unit tests to ensure proper handling of these changes.