### PR TITLE
feat(articles): add article detail page and enhance article handling

### DIFF
--- a/apps/client/src/app/app.routes.server.ts
+++ b/apps/client/src/app/app.routes.server.ts
@@ -2,6 +2,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
     {
+        path: 'articles/:id',
+        renderMode: RenderMode.Server,
+    },
+    {
         path: '**',
         renderMode: RenderMode.Prerender,
     },

--- a/apps/client/src/app/app.routes.ts
+++ b/apps/client/src/app/app.routes.ts
@@ -5,16 +5,12 @@ export const appRoutes: Route[] = [
         path: '',
         pathMatch: 'full',
         loadComponent: () =>
-            import('./pages/main/main.component').then(
-                m => m.MainComponent
-            ),
+            import('./pages/main/main.component').then(m => m.MainComponent),
     },
     {
         path: 'login',
         loadComponent: () =>
-            import('./pages/login/login.component').then(
-                m => m.LoginComponent
-            ),
+            import('./pages/login/login.component').then(m => m.LoginComponent),
     },
     {
         path: 'editor',
@@ -23,8 +19,11 @@ export const appRoutes: Route[] = [
                 m => m.SharedEditorComponent
             ),
     },
-    // {
-    //     path: '**',
-    //     redirectTo: 'article/edit',
-    // },
+    {
+        path: 'articles/:id',
+        loadComponent: () =>
+            import('./pages/article/article.component').then(
+                m => m.ArticleComponent
+            ),
+    },
 ];

--- a/apps/client/src/app/pages/article/article.component.html
+++ b/apps/client/src/app/pages/article/article.component.html
@@ -1,0 +1,19 @@
+@if (isLoading()) {
+    <div class="loading-container">
+        <ui-spinner [diameter]="48" />
+    </div>
+} @else if (error()) {
+    <div class="error-container">
+        <p class="error-message">{{ error() }}</p>
+    </div>
+} @else if (article(); as article) {
+    <article class="article">
+        <header class="article-header">
+            <h1 class="article-title">{{ article.title }}</h1>
+        </header>
+        <div
+            class="article-content"
+            uiInternalLinks
+            [innerHTML]="article.content"></div>
+    </article>
+}

--- a/apps/client/src/app/pages/article/article.component.scss
+++ b/apps/client/src/app/pages/article/article.component.scss
@@ -1,0 +1,37 @@
+.loading-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+}
+
+.error-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 200px;
+}
+
+.error-message {
+    color: var(--themed-test-error);
+}
+
+.article {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1rem;
+}
+
+.article-header {
+    margin-bottom: 1.5rem;
+
+    .article-title {
+        font-size: 1.75rem;
+        font-weight: 500;
+        margin: 0;
+    }
+}
+
+.article-content {
+    line-height: 1.6;
+}

--- a/apps/client/src/app/pages/article/article.component.scss
+++ b/apps/client/src/app/pages/article/article.component.scss
@@ -13,7 +13,7 @@
 }
 
 .error-message {
-    color: var(--themed-test-error);
+    color: var(--themed-text-error);
 }
 
 .article {

--- a/apps/client/src/app/pages/article/article.component.spec.ts
+++ b/apps/client/src/app/pages/article/article.component.spec.ts
@@ -150,8 +150,6 @@ describe('ArticleComponent', () => {
 });
 
 describe('ArticleComponent with invalid ID', () => {
-    let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
-
     const createComponentWithInvalidId = createComponentFactory({
         component: ArticleComponent,
         mocks: [ArticleService, Router],

--- a/apps/client/src/app/pages/article/article.component.spec.ts
+++ b/apps/client/src/app/pages/article/article.component.spec.ts
@@ -1,0 +1,216 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ArticleComponent } from './article.component';
+import { ArticleService } from '../../services/articles';
+import { Article } from '@drevo-web/shared';
+
+describe('ArticleComponent', () => {
+    let spectator: Spectator<ArticleComponent>;
+    let articleService: jest.Mocked<ArticleService>;
+    let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+
+    const mockArticle: Article = {
+        articleId: 123,
+        versionId: 456,
+        title: 'Test Article Title',
+        content: '<p>Test article content</p>',
+        author: 'Test Author',
+        date: new Date('2024-01-15T10:00:00Z'),
+        redirect: false,
+    };
+
+    const createComponent = createComponentFactory({
+        component: ArticleComponent,
+        mocks: [ArticleService, Router],
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useFactory: () => ({
+                    paramMap: paramMapSubject.asObservable(),
+                }),
+            },
+        ],
+        detectChanges: false,
+    });
+
+    beforeEach(() => {
+        paramMapSubject = new BehaviorSubject(convertToParamMap({ id: '123' }));
+        spectator = createComponent();
+        articleService = spectator.inject(
+            ArticleService
+        ) as jest.Mocked<ArticleService>;
+        articleService.getArticle.mockReturnValue(of(mockArticle));
+    });
+
+    it('should create', () => {
+        spectator.detectChanges();
+        expect(spectator.component).toBeTruthy();
+    });
+
+    describe('successful article loading', () => {
+        it('should display spinner while loading', () => {
+            // Use NEVER to keep observable pending (loading state)
+            articleService.getArticle.mockReturnValue(NEVER);
+            spectator.detectChanges();
+
+            expect(spectator.component.isLoading()).toBe(true);
+            expect(spectator.query('ui-spinner')).toBeTruthy();
+            expect(spectator.query('.article')).toBeFalsy();
+        });
+
+        it('should load and display article', () => {
+            spectator.detectChanges();
+
+            expect(articleService.getArticle).toHaveBeenCalledWith(123);
+            expect(spectator.component.article()).toEqual(mockArticle);
+            expect(spectator.component.isLoading()).toBe(false);
+            expect(spectator.query('.article-title')).toHaveText(
+                'Test Article Title'
+            );
+        });
+
+        it('should render article content as HTML', () => {
+            spectator.detectChanges();
+
+            const contentEl = spectator.query('.article-content');
+            expect(contentEl?.innerHTML).toContain(
+                '<p>Test article content</p>'
+            );
+        });
+
+        it('should reload article when route param changes', () => {
+            spectator.detectChanges();
+
+            expect(articleService.getArticle).toHaveBeenCalledWith(123);
+
+            const anotherArticle: Article = {
+                ...mockArticle,
+                articleId: 456,
+                title: 'Another Article',
+            };
+            articleService.getArticle.mockReturnValue(of(anotherArticle));
+
+            paramMapSubject.next(convertToParamMap({ id: '456' }));
+
+            expect(articleService.getArticle).toHaveBeenCalledWith(456);
+            expect(spectator.component.article()).toEqual(anotherArticle);
+        });
+
+        it('should retry loading after error when navigating to same or different article', () => {
+            const error = new HttpErrorResponse({
+                status: 500,
+                statusText: 'Server Error',
+            });
+            articleService.getArticle.mockReturnValue(throwError(() => error));
+            spectator.detectChanges();
+
+            expect(spectator.component.error()).toBe('Ошибка загрузки статьи');
+
+            // Now the server recovers
+            articleService.getArticle.mockReturnValue(of(mockArticle));
+
+            // Navigate to another article
+            paramMapSubject.next(convertToParamMap({ id: '456' }));
+
+            expect(articleService.getArticle).toHaveBeenCalledWith(456);
+            expect(spectator.component.article()).toEqual(mockArticle);
+            expect(spectator.component.error()).toBeUndefined();
+        });
+    });
+
+    describe('error handling', () => {
+        it('should display error message when article not found (404)', () => {
+            const error = new HttpErrorResponse({
+                status: 404,
+                statusText: 'Not Found',
+            });
+            articleService.getArticle.mockReturnValue(throwError(() => error));
+            spectator.detectChanges();
+
+            expect(spectator.component.error()).toBe('Статья не найдена');
+            expect(spectator.component.isLoading()).toBe(false);
+            expect(spectator.query('.error-message')).toHaveText(
+                'Статья не найдена'
+            );
+        });
+
+        it('should display generic error message for other errors', () => {
+            const error = new HttpErrorResponse({
+                status: 500,
+                statusText: 'Server Error',
+            });
+            articleService.getArticle.mockReturnValue(throwError(() => error));
+            spectator.detectChanges();
+
+            expect(spectator.component.error()).toBe('Ошибка загрузки статьи');
+        });
+    });
+});
+
+describe('ArticleComponent with invalid ID', () => {
+    let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+
+    const createComponentWithInvalidId = createComponentFactory({
+        component: ArticleComponent,
+        mocks: [ArticleService, Router],
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useFactory: () => ({
+                    paramMap: of(convertToParamMap({ id: 'invalid' })),
+                }),
+            },
+        ],
+    });
+
+    it('should show error for non-numeric ID', () => {
+        const spectator = createComponentWithInvalidId();
+
+        expect(spectator.component.error()).toBe('Неверный ID статьи');
+        expect(spectator.component.isLoading()).toBe(false);
+    });
+});
+
+describe('ArticleComponent with negative ID', () => {
+    const createComponentWithNegativeId = createComponentFactory({
+        component: ArticleComponent,
+        mocks: [ArticleService, Router],
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useFactory: () => ({
+                    paramMap: of(convertToParamMap({ id: '-5' })),
+                }),
+            },
+        ],
+    });
+
+    it('should show error for negative ID', () => {
+        const spectator = createComponentWithNegativeId();
+
+        expect(spectator.component.error()).toBe('Неверный ID статьи');
+    });
+});
+
+describe('ArticleComponent with zero ID', () => {
+    const createComponentWithZeroId = createComponentFactory({
+        component: ArticleComponent,
+        mocks: [ArticleService, Router],
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useFactory: () => ({
+                    paramMap: of(convertToParamMap({ id: '0' })),
+                }),
+            },
+        ],
+    });
+
+    it('should show error for zero ID', () => {
+        const spectator = createComponentWithZeroId();
+
+        expect(spectator.component.error()).toBe('Неверный ID статьи');
+    });
+});

--- a/apps/client/src/app/pages/article/article.component.ts
+++ b/apps/client/src/app/pages/article/article.component.ts
@@ -1,0 +1,69 @@
+import {
+    ChangeDetectionStrategy,
+    Component,
+    DestroyRef,
+    inject,
+    OnInit,
+    signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { InternalLinksDirective, SpinnerComponent } from '@drevo-web/ui';
+import { Article } from '@drevo-web/shared';
+import { ArticleService } from '../../services/articles';
+import { HttpErrorResponse } from '@angular/common/http';
+
+@Component({
+    selector: 'app-article',
+    imports: [CommonModule, SpinnerComponent, InternalLinksDirective],
+    templateUrl: './article.component.html',
+    styleUrl: './article.component.scss',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ArticleComponent implements OnInit {
+    private readonly route = inject(ActivatedRoute);
+    private readonly articleService = inject(ArticleService);
+    private readonly destroyRef = inject(DestroyRef);
+
+    readonly article = signal<Article | undefined>(undefined);
+    readonly isLoading = signal<boolean | undefined>(undefined);
+    readonly error = signal<string | undefined>(undefined);
+
+    ngOnInit(): void {
+        this.route.paramMap
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(params => {
+                const idParam = params.get('id');
+                const id = idParam ? parseInt(idParam, 10) : NaN;
+
+                if (isNaN(id) || id <= 0) {
+                    this.error.set('Неверный ID статьи');
+                    this.isLoading.set(false);
+                    return;
+                }
+
+                this.loadArticle(id);
+            });
+    }
+
+    private loadArticle(id: number): void {
+        this.isLoading.set(true);
+        this.error.set(undefined);
+
+        this.articleService.getArticle(id).subscribe({
+            next: article => {
+                this.article.set(article);
+                this.isLoading.set(false);
+            },
+            error: (err: HttpErrorResponse) => {
+                if (err.status === 404) {
+                    this.error.set('Статья не найдена');
+                } else {
+                    this.error.set('Ошибка загрузки статьи');
+                }
+                this.isLoading.set(false);
+            },
+        });
+    }
+}

--- a/apps/client/src/app/pages/article/article.component.ts
+++ b/apps/client/src/app/pages/article/article.component.ts
@@ -27,7 +27,7 @@ export class ArticleComponent implements OnInit {
     private readonly destroyRef = inject(DestroyRef);
 
     readonly article = signal<Article | undefined>(undefined);
-    readonly isLoading = signal<boolean | undefined>(undefined);
+    readonly isLoading = signal<boolean>(false);
     readonly error = signal<string | undefined>(undefined);
 
     ngOnInit(): void {

--- a/apps/client/src/app/pages/article/article.component.ts
+++ b/apps/client/src/app/pages/article/article.component.ts
@@ -48,6 +48,7 @@ export class ArticleComponent implements OnInit {
     }
 
     private loadArticle(id: number): void {
+        this.article.set(undefined);
         this.isLoading.set(true);
         this.error.set(undefined);
 

--- a/apps/client/src/app/pages/search/search.component.html
+++ b/apps/client/src/app/pages/search/search.component.html
@@ -26,6 +26,7 @@
                     <a
                         class="search-result-item"
                         [routerLink]="['/articles', result.id]"
+                        (click)="closeModal()"
                         [innerHTML]="
                             result.title | highlight: searchQuery()
                         "></a>

--- a/apps/client/src/app/pages/search/search.component.spec.ts
+++ b/apps/client/src/app/pages/search/search.component.spec.ts
@@ -3,6 +3,7 @@ import { provideRouter } from '@angular/router';
 import { delay, of, throwError } from 'rxjs';
 import { ArticleService } from '../../services/articles';
 import { SearchComponent } from './search.component';
+import { MODAL_DATA, ModalData } from '@drevo-web/ui';
 
 const DEBOUNCE_TIME_MS = 500;
 
@@ -567,6 +568,29 @@ describe('SearchComponent', () => {
                 query: 'new query',
                 page: 1,
             });
+        });
+    });
+
+    describe('closeModal', () => {
+        it('should call modalData.close when modalData is provided', () => {
+            const mockModalData: ModalData = {
+                data: undefined,
+                close: jest.fn(),
+            };
+
+            spectator = createComponent({
+                providers: [{ provide: MODAL_DATA, useValue: mockModalData }],
+            });
+
+            spectator.component.closeModal();
+
+            expect(mockModalData.close).toHaveBeenCalled();
+        });
+
+        it('should not throw error when modalData is not provided', () => {
+            spectator = createComponent();
+
+            expect(() => spectator.component.closeModal()).not.toThrow();
         });
     });
 });

--- a/apps/client/src/app/pages/search/search.component.ts
+++ b/apps/client/src/app/pages/search/search.component.ts
@@ -16,6 +16,8 @@ import {
     VirtualScrollerComponent,
     VirtualScrollerItemDirective,
     HighlightPipe,
+    MODAL_DATA,
+    ModalData,
 } from '@drevo-web/ui';
 import { ArticleSearchResult } from '@drevo-web/shared';
 import {
@@ -49,6 +51,9 @@ const DEBOUNCE_TIME_MS = 500;
 export class SearchComponent implements OnInit {
     private readonly articleService = inject(ArticleService);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly modalData = inject<ModalData>(MODAL_DATA, {
+        optional: true,
+    });
     private readonly searchSubject = new Subject<string>();
 
     readonly searchQuery = signal('');
@@ -71,6 +76,10 @@ export class SearchComponent implements OnInit {
 
     readonly trackByFn = (_index: number, item: ArticleSearchResult): number =>
         item.id;
+
+    closeModal(): void {
+        this.modalData?.close();
+    }
 
     ngOnInit(): void {
         this.searchSubject

--- a/apps/client/src/app/services/articles/article-api.service.spec.ts
+++ b/apps/client/src/app/services/articles/article-api.service.spec.ts
@@ -24,7 +24,7 @@ describe('ArticleApiService', () => {
         httpController.verify();
     });
 
-    const createMockResponse = (
+    const createMockSearchResponse = (
         items: unknown[] = [],
         page = 1,
         pageSize = 25,
@@ -42,7 +42,7 @@ describe('ArticleApiService', () => {
 
     const expectSearchRequest = (
         params: { q?: string; page?: string; size?: string },
-        response = createMockResponse()
+        response = createMockSearchResponse()
     ) => {
         const req = httpController.expectOne(
             request =>
@@ -54,6 +54,70 @@ describe('ArticleApiService', () => {
         req.flush(response);
         return req;
     };
+
+    describe('getArticle', () => {
+        const mockArticleResponse = {
+            success: true,
+            data: {
+                articleId: 123,
+                versionId: 456,
+                title: 'Test Article',
+                content: '<p>Content</p>',
+                author: 'Author',
+                date: '2024-01-15T10:00:00+00:00',
+                redirect: 0,
+            },
+        };
+
+        it('should call HTTP GET with correct URL', () => {
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result).toEqual(mockArticleResponse.data);
+            });
+
+            const req = httpController.expectOne('/api/articles/show/123');
+            expect(req.request.method).toBe('GET');
+            expect(req.request.withCredentials).toBe(true);
+            req.flush(mockArticleResponse);
+        });
+
+        it('should extract data from response wrapper', done => {
+            spectator.service.getArticle(456).subscribe(result => {
+                expect(result.articleId).toBe(123);
+                expect(result.title).toBe('Test Article');
+                done();
+            });
+
+            const req = httpController.expectOne('/api/articles/show/456');
+            req.flush(mockArticleResponse);
+        });
+
+        it('should throw when response.data is undefined', done => {
+            spectator.service.getArticle(123).subscribe({
+                error: (err: Error) => {
+                    expect(err.message).toContain('Response data is undefined');
+                    done();
+                },
+            });
+
+            const req = httpController.expectOne('/api/articles/show/123');
+            req.flush({ success: true, data: undefined });
+        });
+
+        it('should propagate HTTP 404 errors', done => {
+            spectator.service.getArticle(999).subscribe({
+                error: err => {
+                    expect(err.status).toBe(404);
+                    done();
+                },
+            });
+
+            const req = httpController.expectOne('/api/articles/show/999');
+            req.flush(
+                { success: false, error: 'Article not found' },
+                { status: 404, statusText: 'Not Found' }
+            );
+        });
+    });
 
     describe('searchArticles', () => {
         it('should call HTTP GET with correct URL and params and extract data from wrapper', () => {
@@ -73,7 +137,7 @@ describe('ArticleApiService', () => {
 
             const req = expectSearchRequest(
                 { q: 'test', page: '1', size: '25' },
-                createMockResponse(mockData.items, 1, 25, 1)
+                createMockSearchResponse(mockData.items, 1, 25, 1)
             );
 
             expect(req.request.method).toBe('GET');
@@ -103,7 +167,7 @@ describe('ArticleApiService', () => {
                     request.params.get('size') === '25'
                 );
             });
-            req.flush(createMockResponse());
+            req.flush(createMockSearchResponse());
         });
 
         it('should not include q param when query is not provided', () => {
@@ -117,7 +181,7 @@ describe('ArticleApiService', () => {
                     request.params.get('size') === '25'
                 );
             });
-            req.flush(createMockResponse());
+            req.flush(createMockSearchResponse());
         });
     });
 

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import {
     ApiResponse,
     ArticleSearchResponseApi,
+    ArticleDetailApi,
     assertIsDefined,
 } from '@drevo-web/shared';
 import { environment } from '../../../environments/environment';
@@ -25,6 +26,28 @@ import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
 export class ArticleApiService {
     private readonly apiUrl = environment.apiUrl;
     private readonly http = inject(HttpClient);
+
+    /**
+     * Get article by ID
+     *
+     * @param id - Article ID
+     * @returns Observable with raw API response
+     */
+    getArticle(id: number): Observable<ArticleDetailApi> {
+        return this.http
+            .get<
+                ApiResponse<ArticleDetailApi>
+            >(`${this.apiUrl}/api/articles/show/${id}`, { withCredentials: true })
+            .pipe(
+                map(response => {
+                    assertIsDefined(
+                        response.data,
+                        'Response data is undefined'
+                    );
+                    return response.data;
+                })
+            );
+    }
 
     /**
      * Search articles by title

--- a/apps/client/src/app/services/articles/article.service.spec.ts
+++ b/apps/client/src/app/services/articles/article.service.spec.ts
@@ -1,6 +1,6 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
-import { ArticleSearchResponseApi } from '@drevo-web/shared';
+import { ArticleSearchResponseApi, ArticleDetailApi } from '@drevo-web/shared';
 import { ArticleService } from './article.service';
 import { ArticleApiService } from './article-api.service';
 
@@ -18,6 +18,113 @@ describe('ArticleService', () => {
         articleApiService = spectator.inject(
             ArticleApiService
         ) as jest.Mocked<ArticleApiService>;
+    });
+
+    describe('getArticle', () => {
+        const mockApiResponse: ArticleDetailApi = {
+            articleId: 123,
+            versionId: 456,
+            title: 'Test Article',
+            content: '<p>Content</p>',
+            author: 'Test Author',
+            date: '2024-01-15T10:00:00+00:00',
+            redirect: 0,
+        };
+
+        it('should call articleApiService.getArticle with correct id', () => {
+            articleApiService.getArticle.mockReturnValue(of(mockApiResponse));
+
+            spectator.service.getArticle(123).subscribe();
+
+            expect(articleApiService.getArticle).toHaveBeenCalledWith(123);
+        });
+
+        it('should map API response to frontend model', done => {
+            articleApiService.getArticle.mockReturnValue(of(mockApiResponse));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.articleId).toBe(123);
+                expect(result.versionId).toBe(456);
+                expect(result.title).toBe('Test Article');
+                expect(result.content).toBe('<p>Content</p>');
+                expect(result.author).toBe('Test Author');
+                expect(result.redirect).toBe(false);
+                done();
+            });
+        });
+
+        it('should convert date string to Date object', done => {
+            articleApiService.getArticle.mockReturnValue(of(mockApiResponse));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.date).toBeInstanceOf(Date);
+                expect(result.date.toISOString()).toBe(
+                    '2024-01-15T10:00:00.000Z'
+                );
+                done();
+            });
+        });
+
+        it('should map redirect=1 to true', done => {
+            const redirectArticle: ArticleDetailApi = {
+                ...mockApiResponse,
+                redirect: 1,
+            };
+            articleApiService.getArticle.mockReturnValue(of(redirectArticle));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.redirect).toBe(true);
+                done();
+            });
+        });
+
+        it('should transform article links removing .html extension', done => {
+            const articleWithLinks: ArticleDetailApi = {
+                ...mockApiResponse,
+                content:
+                    '<a class="existlink" href="/articles/8.html">Link</a>',
+            };
+            articleApiService.getArticle.mockReturnValue(of(articleWithLinks));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.content).toBe(
+                    '<a class="existlink" href="/articles/8">Link</a>'
+                );
+                done();
+            });
+        });
+
+        it('should transform multiple article links', done => {
+            const articleWithLinks: ArticleDetailApi = {
+                ...mockApiResponse,
+                content:
+                    '<p><a href="/articles/1.html">First</a> and <a href="/articles/999.html">Second</a></p>',
+            };
+            articleApiService.getArticle.mockReturnValue(of(articleWithLinks));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.content).toBe(
+                    '<p><a href="/articles/1">First</a> and <a href="/articles/999">Second</a></p>'
+                );
+                done();
+            });
+        });
+
+        it('should not transform non-article links', done => {
+            const articleWithLinks: ArticleDetailApi = {
+                ...mockApiResponse,
+                content:
+                    '<a href="https://example.com">External</a> <a href="/other/page.html">Other</a>',
+            };
+            articleApiService.getArticle.mockReturnValue(of(articleWithLinks));
+
+            spectator.service.getArticle(123).subscribe(result => {
+                expect(result.content).toBe(
+                    '<a href="https://example.com">External</a> <a href="/other/page.html">Other</a>'
+                );
+                done();
+            });
+        });
     });
 
     describe('searchArticles', () => {

--- a/apps/client/src/app/services/articles/article.service.ts
+++ b/apps/client/src/app/services/articles/article.service.ts
@@ -2,6 +2,8 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
+    Article,
+    ArticleDetailApi,
     ArticleSearchResponseApi,
     ArticleSearchResultApi,
     ArticleSearchResponse,
@@ -25,6 +27,18 @@ export class ArticleService {
     private readonly articleApiService = inject(ArticleApiService);
 
     /**
+     * Get article by ID
+     *
+     * @param id - Article ID
+     * @returns Observable with mapped article
+     */
+    getArticle(id: number): Observable<Article> {
+        return this.articleApiService
+            .getArticle(id)
+            .pipe(map(response => this.mapArticle(response)));
+    }
+
+    /**
      * Search articles by title
      *
      * @param params - Search parameters (query is optional - empty returns all articles)
@@ -42,6 +56,30 @@ export class ArticleService {
         return this.articleApiService
             .searchArticles(query, page, pageSize)
             .pipe(map(response => this.mapSearchResponse(response)));
+    }
+
+    private mapArticle(response: ArticleDetailApi): Article {
+        return {
+            articleId: response.articleId,
+            versionId: response.versionId,
+            title: response.title,
+            content: this.transformArticleLinks(response.content),
+            author: response.author,
+            date: new Date(response.date),
+            redirect: response.redirect === 1,
+        };
+    }
+
+    /**
+     * Transform legacy article links to Angular-friendly format.
+     * Converts href="/articles/8.html" to href="/articles/8"
+     */
+    private transformArticleLinks(content: string): string {
+        // Match href attributes pointing to /articles/*.html
+        return content.replace(
+            /href="\/articles\/(\d+)\.html"/g,
+            'href="/articles/$1"'
+        );
     }
 
     private mapSearchResponse(

--- a/libs/shared/src/lib/models/api/article.api.ts
+++ b/libs/shared/src/lib/models/api/article.api.ts
@@ -1,0 +1,17 @@
+/**
+ * API response interfaces for article detail
+ * These interfaces represent the raw API response structure for single article
+ */
+
+/**
+ * Article detail response from API
+ */
+export interface ArticleDetailApi {
+    readonly articleId: number;
+    readonly versionId: number;
+    readonly title: string;
+    readonly content: string;
+    readonly author: string;
+    readonly date: string; // ISO 8601 format
+    readonly redirect: number;
+}

--- a/libs/shared/src/lib/models/api/index.ts
+++ b/libs/shared/src/lib/models/api/index.ts
@@ -1,1 +1,2 @@
 export * from './article-search.api';
+export * from './article.api';

--- a/libs/shared/src/lib/models/article.ts
+++ b/libs/shared/src/lib/models/article.ts
@@ -1,6 +1,13 @@
+/**
+ * Frontend interface for article detail
+ * Used in the application layer after mapping from API
+ */
 export interface Article {
-    articleId: number;
-    versionId: number;
-    title: string;
-    content: string;
+    readonly articleId: number;
+    readonly versionId: number;
+    readonly title: string;
+    readonly content: string;
+    readonly author: string;
+    readonly date: Date;
+    readonly redirect: boolean;
 }

--- a/libs/ui/src/index.ts
+++ b/libs/ui/src/index.ts
@@ -3,5 +3,6 @@ export * from './lib/components/spinner/spinner.component';
 export * from './lib/components/text-input/text-input.component';
 export * from './lib/components/virtual-scroller/virtual-scroller.component';
 export * from './lib/components/virtual-scroller/virtual-scroller-item.directive';
+export * from './lib/directives/internal-links/internal-links.directive';
 export * from './lib/modal';
 export * from './lib/pipes/highlight/highlight.pipe';

--- a/libs/ui/src/lib/directives/internal-links/internal-links.directive.spec.ts
+++ b/libs/ui/src/lib/directives/internal-links/internal-links.directive.spec.ts
@@ -1,0 +1,130 @@
+import { Router } from '@angular/router';
+import {
+    createDirectiveFactory,
+    SpectatorDirective,
+} from '@ngneat/spectator/jest';
+import { InternalLinksDirective } from './internal-links.directive';
+
+describe('InternalLinksDirective', () => {
+    let spectator: SpectatorDirective<InternalLinksDirective>;
+    let router: jest.Mocked<Router>;
+
+    const createDirective = createDirectiveFactory({
+        directive: InternalLinksDirective,
+        mocks: [Router],
+    });
+
+    beforeEach(() => {
+        router = undefined!;
+    });
+
+    function setup(content: string): void {
+        spectator = createDirective(
+            `<div uiInternalLinks>${content}</div>`
+        );
+        router = spectator.inject(Router) as jest.Mocked<Router>;
+    }
+
+    describe('internal link navigation', () => {
+        it('should navigate using router for internal links', () => {
+            setup('<a href="/articles/123">Article Link</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            link.click();
+
+            expect(router.navigateByUrl).toHaveBeenCalledWith('/articles/123');
+        });
+
+        it('should prevent default browser navigation for internal links', () => {
+            setup('<a href="/articles/456">Article Link</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            const event = new MouseEvent('click', {
+                bubbles: true,
+                cancelable: true,
+            });
+            const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+            link.dispatchEvent(event);
+
+            expect(preventDefaultSpy).toHaveBeenCalled();
+        });
+
+        it('should handle nested elements inside links', () => {
+            setup('<a href="/articles/789"><span>Nested Text</span></a>');
+
+            const span = spectator.query('span') as HTMLSpanElement;
+            span.click();
+
+            expect(router.navigateByUrl).toHaveBeenCalledWith('/articles/789');
+        });
+    });
+
+    describe('external link handling', () => {
+        it('should not intercept external http links', () => {
+            setup('<a href="https://example.com">External</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            link.click();
+
+            expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+
+        it('should not intercept mailto links', () => {
+            setup('<a href="mailto:test@example.com">Email</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            link.click();
+
+            expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+
+        it('should not intercept hash-only links', () => {
+            setup('<a href="/#section">Hash Link</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            link.click();
+
+            expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('non-link clicks', () => {
+        it('should not intercept clicks on non-link elements', () => {
+            setup('<p>Plain text</p>');
+
+            const paragraph = spectator.query('p') as HTMLParagraphElement;
+            paragraph.click();
+
+            expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+
+        it('should not intercept clicks on links without href', () => {
+            setup('<a>No href</a>');
+
+            const link = spectator.query('a') as HTMLAnchorElement;
+            link.click();
+
+            expect(router.navigateByUrl).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('cleanup', () => {
+        it('should remove event listener on destroy', () => {
+            setup('<a href="/test">Link</a>');
+
+            const hostElement = spectator.directive['elementRef'].nativeElement;
+            const removeEventListenerSpy = jest.spyOn(
+                hostElement,
+                'removeEventListener'
+            );
+
+            spectator.directive.ngOnDestroy();
+
+            expect(removeEventListenerSpy).toHaveBeenCalledWith(
+                'click',
+                expect.any(Function)
+            );
+        });
+    });
+});

--- a/libs/ui/src/lib/directives/internal-links/internal-links.directive.ts
+++ b/libs/ui/src/lib/directives/internal-links/internal-links.directive.ts
@@ -1,0 +1,85 @@
+import {
+    Directive,
+    ElementRef,
+    inject,
+    OnDestroy,
+    OnInit,
+} from '@angular/core';
+import { Router } from '@angular/router';
+
+/**
+ * Directive that intercepts clicks on internal links within dynamic HTML content
+ * and navigates using Angular Router instead of full page reload.
+ *
+ * This is useful for rendering HTML content with links (e.g., from API)
+ * that should use client-side navigation.
+ *
+ * @example
+ * ```html
+ * <div [innerHTML]="article.content" uiInternalLinks></div>
+ * ```
+ *
+ * The directive intercepts clicks on links that:
+ * - Have href starting with "/" (internal links)
+ * - Are not external links (http://, https://, mailto:, etc.)
+ */
+@Directive({
+    selector: '[uiInternalLinks]',
+})
+export class InternalLinksDirective implements OnInit, OnDestroy {
+    private readonly elementRef = inject(ElementRef<HTMLElement>);
+    private readonly router = inject(Router);
+
+    private readonly clickHandler = (event: MouseEvent): void => {
+        const target = event.target as HTMLElement;
+        const anchor = target.closest('a');
+
+        if (!anchor) {
+            return;
+        }
+
+        const href = anchor.getAttribute('href');
+
+        if (!href) {
+            return;
+        }
+
+        // Only handle internal links (starting with /)
+        // Skip external links and special protocols
+        if (this.isInternalLink(href)) {
+            event.preventDefault();
+            this.router.navigateByUrl(href);
+        }
+    };
+
+    ngOnInit(): void {
+        this.elementRef.nativeElement.addEventListener(
+            'click',
+            this.clickHandler
+        );
+    }
+
+    ngOnDestroy(): void {
+        this.elementRef.nativeElement.removeEventListener(
+            'click',
+            this.clickHandler
+        );
+    }
+
+    /**
+     * Check if the href is an internal link that should be handled by Angular Router
+     */
+    private isInternalLink(href: string): boolean {
+        // Internal links start with /
+        if (!href.startsWith('/')) {
+            return false;
+        }
+
+        // Skip hash-only links
+        if (href.startsWith('/#')) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/libs/ui/src/lib/directives/internal-links/internal-links.directive.ts
+++ b/libs/ui/src/lib/directives/internal-links/internal-links.directive.ts
@@ -76,10 +76,6 @@ export class InternalLinksDirective implements OnInit, OnDestroy {
         }
 
         // Skip hash-only links
-        if (href.startsWith('/#')) {
-            return false;
-        }
-
-        return true;
+        return !href.startsWith('/#');
     }
 }

--- a/libs/ui/src/lib/styles/_theme-colors.scss
+++ b/libs/ui/src/lib/styles/_theme-colors.scss
@@ -44,6 +44,10 @@ $theme-colors: (
         light: $md-grey-500,
         dark: $md-grey-600,
     ),
+    text-error: (
+        light: $md-red-800,
+        dark: $md-red-500,
+    ),
     // Menu
     menu-hover-background: (
             light: $md-grey-300,


### PR DESCRIPTION
- Created `ArticleComponent` for displaying article details.
- Introduced routes for `/articles/:id` with appropriate lazy loading and navigation improvements.
- Added `getArticle` method to `ArticleService` for article retrieval.
- Enhanced HTML content linking using the `InternalLinksDirective` directive.
- Improved article content handling by transforming legacy `.html` links.
- Updated styles and tests to support these changes.