### PR TITLE
feat(article): add support for legacy interactive features and improv…

### DIFF
--- a/apps/client/src/app/pages/article/article-content/article-content.component.scss
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.scss
@@ -14,7 +14,12 @@ app-article-content {
     scroll-behavior: smooth;
 
     a {
-        color: var(--themed-wiki-default-link);
+        color: var(--themed-link);
+    }
+
+    .link-note,
+    .link-source {
+        color: var(--themed-wiki-note-link);
     }
 
     .external {

--- a/apps/client/src/app/pages/article/article-content/article-content.component.scss
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.scss
@@ -14,7 +14,7 @@ app-article-content {
     scroll-behavior: smooth;
 
     a {
-        color: var(--themed-link);
+        color: var(--themed-link-color);
     }
 
     .link-note,

--- a/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
@@ -1,19 +1,24 @@
 import { Router } from '@angular/router';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { LoggerService } from '@drevo-web/core';
+import { mockLoggerProvider, MockLoggerService } from '@drevo-web/core/testing';
 import { ArticleContentComponent } from './article-content.component';
 
 describe('ArticleContentComponent', () => {
     let spectator: Spectator<ArticleContentComponent>;
     let router: jest.Mocked<Router>;
+    let logger: MockLoggerService;
 
     const createComponent = createComponentFactory({
         component: ArticleContentComponent,
         mocks: [Router],
+        providers: [mockLoggerProvider()],
     });
 
     beforeEach(() => {
         spectator = createComponent();
         router = spectator.inject(Router) as jest.Mocked<Router>;
+        logger = spectator.inject(LoggerService) as unknown as MockLoggerService;
     });
 
     afterEach(() => {
@@ -473,6 +478,114 @@ describe('ArticleContentComponent', () => {
                 link.click();
 
                 expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should handle javascript: links with uppercase (JavaScript:)', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="JavaScript:toggleAll()">Toggle</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should handle javascript: links with mixed case', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="JaVaScRiPt:toggleRus()">Toggle</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should handle javascript: links with whitespace', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="  javascript:toggleCsl()  ">Toggle</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should reject invalid javascript: patterns with special characters', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:alert(\'xss\')">Invalid</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                // Should log warning but not execute any action
+                expect(logger.mockLogger.warn).toHaveBeenCalledWith(
+                    'Invalid javascript action format',
+                    expect.objectContaining({ href: expect.any(String) })
+                );
+            });
+
+            it('should reject unknown javascript: actions', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:unknownAction()">Unknown</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+
+                link.dispatchEvent(event);
+
+                expect(logger.mockLogger.warn).toHaveBeenCalledWith(
+                    'Unknown javascript action',
+                    expect.objectContaining({ 
+                        action: 'unknownAction',
+                        href: expect.any(String)
+                    })
+                );
             });
         });
     });

--- a/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
@@ -18,7 +18,9 @@ describe('ArticleContentComponent', () => {
     beforeEach(() => {
         spectator = createComponent();
         router = spectator.inject(Router) as jest.Mocked<Router>;
-        logger = spectator.inject(LoggerService) as unknown as MockLoggerService;
+        logger = spectator.inject(
+            LoggerService
+        ) as unknown as MockLoggerService;
     });
 
     afterEach(() => {
@@ -559,8 +561,11 @@ describe('ArticleContentComponent', () => {
                 expect(preventDefaultSpy).toHaveBeenCalled();
                 // Should log warning but not execute any action
                 expect(logger.mockLogger.warn).toHaveBeenCalledWith(
-                    'Invalid javascript action format',
-                    expect.objectContaining({ href: expect.any(String) })
+                    'Unknown javascript action',
+                    expect.objectContaining({
+                        action: 'alert',
+                        value: expect.any(String),
+                    })
                 );
             });
 
@@ -581,11 +586,180 @@ describe('ArticleContentComponent', () => {
 
                 expect(logger.mockLogger.warn).toHaveBeenCalledWith(
                     'Unknown javascript action',
-                    expect.objectContaining({ 
+                    expect.objectContaining({
                         action: 'unknownAction',
-                        href: expect.any(String)
+                        value: expect.any(String),
                     })
                 );
+            });
+
+            it('should reject data: protocol links', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="data:text/html,<script>alert(1)</script>">XSS</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should reject vbscript: protocol links', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="vbscript:msgbox(1)">XSS</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+
+            it('should warn on invalid javascript action format', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:console.log(\'test\')">Invalid</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                link.click();
+
+                expect(logger.mockLogger.warn).toHaveBeenCalledWith(
+                    'Invalid javascript action format',
+                    expect.objectContaining({ value: expect.any(String) })
+                );
+            });
+        });
+
+        describe('toggleGroup', () => {
+            it('should toggle elements with specified class name', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <a href="javascript:toggleGroup('group1')">Toggle Group</a>
+                    <div class="group1">Item 1</div>
+                    <div class="group1">Item 2</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const items = spectator.queryAll<HTMLElement>('.group1');
+
+                // Initial state - visible
+                expect(items[0].style.display).toBe('');
+                expect(items[1].style.display).toBe('');
+
+                // Click to hide
+                link.click();
+
+                expect(items[0].style.display).toBe('none');
+                expect(items[1].style.display).toBe('none');
+
+                // Click to show
+                link.click();
+
+                expect(items[0].style.display).toBe('');
+                expect(items[1].style.display).toBe('');
+            });
+
+            it('should warn when toggleGroup called without parameter', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:toggleGroup()">Invalid</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                link.click();
+
+                expect(logger.mockLogger.warn).toHaveBeenCalledWith(
+                    'toggleGroup requires a class name parameter',
+                    expect.objectContaining({ value: expect.any(String) })
+                );
+            });
+        });
+
+        describe('onclick attribute handling', () => {
+            it('should convert onclick to data-onclick and handle clicks', () => {
+                spectator.setInput(
+                    'content',
+                    `<table onclick="javascript:toggleGroup('cmnt3')"><tr><td>Click me</td></tr></table>
+                    <div class="cmnt3">Content</div>`
+                );
+                spectator.detectChanges();
+
+                const table = spectator.query('table') as HTMLTableElement;
+                const td = spectator.query('td') as HTMLTableCellElement;
+                const content = spectator.query<HTMLElement>('.cmnt3')!;
+
+                // onclick should be converted to data-onclick
+                expect(table.getAttribute('onclick')).toBeNull();
+                expect(table.getAttribute('data-onclick')).toContain(
+                    'javascript:toggleGroup'
+                );
+
+                // Initial state
+                expect(content.style.display).toBe('');
+
+                // Click on child element (td)
+                td.click();
+
+                // Should toggle visibility
+                expect(content.style.display).toBe('none');
+            });
+
+            it('should handle onclick with single quotes', () => {
+                spectator.setInput(
+                    'content',
+                    `<div onclick='javascript:toggleAll()' id="clickable">Click</div>
+                    <div class="cmnt">Comment</div>`
+                );
+                spectator.detectChanges();
+
+                const div = spectator.query('#clickable') as HTMLDivElement;
+
+                expect(div.getAttribute('onclick')).toBeNull();
+                expect(div.getAttribute('data-onclick')).toContain(
+                    'javascript:toggleAll'
+                );
+            });
+
+            it('should handle onclick on nested elements', () => {
+                spectator.setInput(
+                    'content',
+                    `<table onclick="javascript:toggleGroup('test')">
+                        <tr><td><span>Deep nested</span></td></tr>
+                    </table>
+                    <div class="test">Content</div>`
+                );
+                spectator.detectChanges();
+
+                const span = spectator.query('span') as HTMLSpanElement;
+                const content = spectator.query<HTMLElement>('.test')!;
+
+                span.click();
+
+                expect(content.style.display).toBe('none');
             });
         });
     });

--- a/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.spec.ts
@@ -280,4 +280,200 @@ describe('ArticleContentComponent', () => {
             );
         });
     });
+
+    describe('legacy interactive features', () => {
+        describe('toggleAll', () => {
+            it('should toggle comment visibility and link text', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleAll()" class="LinkComment">Свернуть</a></p>
+                    <div class="cmnt">Comment 1</div>
+                    <div class="cmnt">Comment 2</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('.LinkComment') as HTMLElement;
+                const comments = spectator.queryAll<HTMLElement>('.cmnt');
+
+                // Initial state
+                expect(link.textContent?.trim()).toBe('Свернуть');
+                expect(comments[0].style.display).toBe('');
+
+                // Click to collapse
+                link.click();
+
+                expect(link.textContent?.trim()).toBe('Развернуть');
+                expect(comments[0].style.display).toBe('none');
+                expect(comments[1].style.display).toBe('none');
+
+                // Click to expand
+                link.click();
+
+                expect(link.textContent?.trim()).toBe('Свернуть');
+                expect(comments[0].style.display).toBe('');
+                expect(comments[1].style.display).toBe('');
+            });
+
+            it('should handle multiple toggle links', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleAll()" class="LinkComment">Свернуть</a></p>
+                    <div class="cmnt">Comment</div>
+                    <p><a href="javascript:toggleAll()" class="LinkComment">Свернуть</a></p>
+                `
+                );
+                spectator.detectChanges();
+
+                const links = spectator.queryAll<HTMLElement>('.LinkComment');
+
+                links[0].click();
+
+                expect(links[0].textContent?.trim()).toBe('Развернуть');
+                expect(links[1].textContent?.trim()).toBe('Развернуть');
+            });
+        });
+
+        describe('toggleRus', () => {
+            it('should toggle Russian translation visibility', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleRus()" class="toggleRus">Скрыть русский перевод</a></p>
+                    <div class="BibleRus">Russian text</div>
+                    <div class="BibleCsl">Church Slavonic text</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('.toggleRus') as HTMLElement;
+                const rusElement = spectator.query<HTMLElement>('.BibleRus')!;
+                const cslElement = spectator.query<HTMLElement>('.BibleCsl')!;
+
+                // Click to hide Russian
+                link.click();
+
+                expect(rusElement.style.display).toBe('none');
+                expect(cslElement.style.display).toBe('');
+                expect(link.textContent?.trim()).toBe(
+                    'Показать русский перевод'
+                );
+
+                // Click to show Russian
+                link.click();
+
+                expect(rusElement.style.display).toBe('');
+                expect(link.textContent?.trim()).toBe('Скрыть русский перевод');
+            });
+
+            it('should ensure Church Slavonic is visible when hiding Russian', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleRus()" class="toggleRus">Скрыть русский перевод</a></p>
+                    <div class="BibleRus">Russian</div>
+                    <div class="BibleCsl" style="display: none;">Church Slavonic</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('.toggleRus') as HTMLElement;
+                const cslElement = spectator.query<HTMLElement>('.BibleCsl')!;
+
+                link.click();
+
+                expect(cslElement.style.display).toBe('');
+            });
+        });
+
+        describe('toggleCsl', () => {
+            it('should toggle Church Slavonic translation visibility', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleCsl()" class="toggleCsl">Скрыть церковнославянский перевод</a></p>
+                    <div class="BibleRus">Russian text</div>
+                    <div class="BibleCsl">Church Slavonic text</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('.toggleCsl') as HTMLElement;
+                const rusElement = spectator.query<HTMLElement>('.BibleRus')!;
+                const cslElement = spectator.query<HTMLElement>('.BibleCsl')!;
+
+                // Click to hide Church Slavonic
+                link.click();
+
+                expect(cslElement.style.display).toBe('none');
+                expect(rusElement.style.display).toBe('');
+                expect(link.textContent?.trim()).toBe(
+                    'Показать церковнославянский перевод'
+                );
+
+                // Click to show Church Slavonic
+                link.click();
+
+                expect(cslElement.style.display).toBe('');
+                expect(link.textContent?.trim()).toBe(
+                    'Скрыть церковнославянский перевод'
+                );
+            });
+
+            it('should ensure Russian is visible when hiding Church Slavonic', () => {
+                spectator.setInput(
+                    'content',
+                    `
+                    <p><a href="javascript:toggleCsl()" class="toggleCsl">Скрыть церковнославянский перевод</a></p>
+                    <div class="BibleRus" style="display: none;">Russian</div>
+                    <div class="BibleCsl">Church Slavonic</div>
+                `
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('.toggleCsl') as HTMLElement;
+                const rusElement = spectator.query<HTMLElement>('.BibleRus')!;
+
+                link.click();
+
+                expect(rusElement.style.display).toBe('');
+            });
+        });
+
+        describe('javascript: link handling', () => {
+            it('should prevent default for javascript: links', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:toggleAll()">Toggle</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                const event = new MouseEvent('click', {
+                    bubbles: true,
+                    cancelable: true,
+                });
+                const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+
+                link.dispatchEvent(event);
+
+                expect(preventDefaultSpy).toHaveBeenCalled();
+            });
+
+            it('should not call router.navigateByUrl for javascript: links', () => {
+                spectator.setInput(
+                    'content',
+                    '<a href="javascript:toggleAll()">Toggle</a>'
+                );
+                spectator.detectChanges();
+
+                const link = spectator.query('a') as HTMLAnchorElement;
+                link.click();
+
+                expect(router.navigateByUrl).not.toHaveBeenCalled();
+            });
+        });
+    });
 });

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -66,7 +66,10 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
     @Input()
     set content(value: string) {
         this._content = value;
-        this._sanitizedContent = this.sanitizer.bypassSecurityTrustHtml(value);
+        // Convert onclick="javascript:..." to data-onclick before sanitizing
+        const processedValue = this.preprocessContent(value);
+        this._sanitizedContent =
+            this.sanitizer.bypassSecurityTrustHtml(processedValue);
     }
 
     get content(): string {
@@ -85,29 +88,34 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
 
     private readonly clickHandler = (event: MouseEvent): void => {
         const target = event.target as HTMLElement;
-        const anchor = target.closest('a');
 
+        // Check for data-onclick attribute on clicked element or its parents
+        let element: HTMLElement | null = target;
+        while (element && element !== this.elementRef.nativeElement) {
+            const dataOnclick = element.getAttribute('data-onclick');
+            if (dataOnclick && this.isJavaScriptProtocol(dataOnclick)) {
+                event.preventDefault();
+                this.executeJavaScriptAction(dataOnclick);
+                return;
+            }
+            element = element.parentElement;
+        }
+
+        // Then check for anchor links
+        const anchor = target.closest('a');
         if (!anchor) {
             return;
         }
 
         const href = anchor.getAttribute('href');
-
         if (!href) {
             return;
         }
 
         // Handle javascript: protocol links (legacy interactive features)
-        // TODO: Remove when migrating wiki formatter to Angular
-        // Normalize href to prevent bypass attempts (JavaScript:, java script:, etc.)
-        const normalizedHref = href.trim().toLowerCase().replace(/\s+/g, '');
-        if (
-            normalizedHref.startsWith('javascript:') ||
-            normalizedHref.startsWith('data:') ||
-            normalizedHref.startsWith('vbscript:')
-        ) {
+        if (this.isJavaScriptProtocol(href)) {
             event.preventDefault();
-            this.handleJavaScriptAction(href);
+            this.executeJavaScriptAction(href);
             return;
         }
 
@@ -131,6 +139,18 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
         this.elementRef.nativeElement.addEventListener(
             'click',
             this.clickHandler
+        );
+    }
+
+    /**
+     * Preprocess HTML content to convert onclick="javascript:..." to data-onclick
+     * This prevents browser from trying to execute undefined functions
+     * Uses regex to work in both browser and SSR contexts
+     */
+    private preprocessContent(html: string): string {
+        return html.replace(
+            /\s+onclick=(["'])(javascript:[\s\S]*?)\1/gi,
+            ' data-onclick=$1$2$1'
         );
     }
 
@@ -185,23 +205,43 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
     // ========================================================================
 
     /**
-     * Handle javascript: protocol links from legacy content
-     * @param href - The href attribute value (e.g., "javascript:toggleAll()")
+     * Check if string is a javascript: protocol (with normalization to prevent bypass)
      */
-    private handleJavaScriptAction(href: string): void {
-        // Whitelist of allowed actions to prevent code injection
-        const allowedActions = ['toggleAll', 'toggleRus', 'toggleCsl'] as const;
-        
-        // Extract action name using regex that matches only safe patterns
-        // Matches: javascript:actionName or javascript:actionName()
-        const match = /^javascript:([a-zA-Z]+)(?:\(\))?$/i.exec(href.trim());
-        
-        if (!match) {
-            this.logger.warn('Invalid javascript action format', { href });
+    private isJavaScriptProtocol(value: string): boolean {
+        const normalized = value.trim().toLowerCase().replace(/\s+/g, '');
+        return (
+            normalized.startsWith('javascript:') ||
+            normalized.startsWith('data:') ||
+            normalized.startsWith('vbscript:')
+        );
+    }
+
+    /**
+     * Execute javascript: protocol action from legacy content
+     * @param value - The href or onclick attribute value (e.g., "javascript:toggleAll()")
+     */
+    private executeJavaScriptAction(value: string): void {
+        // Extract action name and parameter using regex
+        const matchSimple = /^javascript:([a-zA-Z]+)(?:\(\))?$/i.exec(
+            value.trim()
+        );
+        const matchWithParam =
+            /^javascript:([a-zA-Z]+)\('([a-zA-Z0-9_-]+)'\)$/i.exec(
+                value.trim()
+            );
+
+        let action: string;
+        let param: string | undefined;
+
+        if (matchWithParam) {
+            action = matchWithParam[1];
+            param = matchWithParam[2];
+        } else if (matchSimple) {
+            action = matchSimple[1];
+        } else {
+            this.logger.warn('Invalid javascript action format', { value });
             return;
         }
-        
-        const action = match[1];
 
         switch (action) {
             case 'toggleAll':
@@ -213,9 +253,21 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
             case 'toggleCsl':
                 this.toggleCsl();
                 break;
-            default:
-                this.logger.warn('Unknown javascript action', { action, href });
+            case 'toggleGroup':
+                if (param) {
+                    this.toggleGroup(param);
+                } else {
+                    this.logger.warn(
+                        'toggleGroup requires a class name parameter',
+                        { value }
+                    );
+                }
                 break;
+            default:
+                this.logger.warn('Unknown javascript action', {
+                    action,
+                    value,
+                });
         }
     }
 

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -101,7 +101,11 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
         // TODO: Remove when migrating wiki formatter to Angular
         // Normalize href to prevent bypass attempts (JavaScript:, java script:, etc.)
         const normalizedHref = href.trim().toLowerCase().replace(/\s+/g, '');
-        if (normalizedHref.startsWith('javascript:')) {
+        if (
+            normalizedHref.startsWith('javascript:') ||
+            normalizedHref.startsWith('data:') ||
+            normalizedHref.startsWith('vbscript:')
+        ) {
             event.preventDefault();
             this.handleJavaScriptAction(href);
             return;

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -99,7 +99,9 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
 
         // Handle javascript: protocol links (legacy interactive features)
         // TODO: Remove when migrating wiki formatter to Angular
-        if (href.startsWith('javascript:')) {
+        // Normalize href to prevent bypass attempts (JavaScript:, java script:, etc.)
+        const normalizedHref = href.trim().toLowerCase().replace(/\s+/g, '');
+        if (normalizedHref.startsWith('javascript:')) {
             event.preventDefault();
             this.handleJavaScriptAction(href);
             return;
@@ -183,7 +185,19 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
      * @param href - The href attribute value (e.g., "javascript:toggleAll()")
      */
     private handleJavaScriptAction(href: string): void {
-        const action = href.replace('javascript:', '').replace(/\(\).*$/, '');
+        // Whitelist of allowed actions to prevent code injection
+        const allowedActions = ['toggleAll', 'toggleRus', 'toggleCsl'] as const;
+        
+        // Extract action name using regex that matches only safe patterns
+        // Matches: javascript:actionName or javascript:actionName()
+        const match = /^javascript:([a-zA-Z]+)(?:\(\))?$/i.exec(href.trim());
+        
+        if (!match) {
+            this.logger.warn('Invalid javascript action format', { href });
+            return;
+        }
+        
+        const action = match[1];
 
         switch (action) {
             case 'toggleAll':

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -10,6 +10,17 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { LoggerService } from '@drevo-web/core';
+
+/**
+ * State interface for managing interactive content visibility
+ * TODO: Remove when migrating wiki formatter to Angular
+ */
+interface ContentInteractionState {
+    commentsExpanded: boolean;
+    rusVisible: boolean;
+    cslVisible: boolean;
+}
 
 /**
  * Component for rendering article content with internal link handling.
@@ -40,6 +51,16 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
     private _sanitizedContent: SafeHtml = '';
 
     /**
+     * State for managing interactive content visibility (comments, translations)
+     * TODO: Remove when migrating wiki formatter to Angular
+     */
+    private interactionState: ContentInteractionState = {
+        commentsExpanded: true,
+        rusVisible: true,
+        cslVisible: true,
+    };
+
+    /**
      * HTML content to render
      */
     @Input()
@@ -59,6 +80,8 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
     private readonly elementRef = inject(ElementRef<HTMLElement>);
     private readonly router = inject(Router);
     private readonly sanitizer = inject(DomSanitizer);
+    private readonly logger =
+        inject(LoggerService).withContext('ArticleContent');
 
     private readonly clickHandler = (event: MouseEvent): void => {
         const target = event.target as HTMLElement;
@@ -71,6 +94,14 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
         const href = anchor.getAttribute('href');
 
         if (!href) {
+            return;
+        }
+
+        // Handle javascript: protocol links (legacy interactive features)
+        // TODO: Remove when migrating wiki formatter to Angular
+        if (href.startsWith('javascript:')) {
+            event.preventDefault();
+            this.handleJavaScriptAction(href);
             return;
         }
 
@@ -141,5 +172,168 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
             const url = `${window.location.pathname}${window.location.search}#${anchorId}`;
             history.pushState(undefined, '', url);
         }
+    }
+
+    // ========================================================================
+    // Legacy interactive features support (TODO: Remove after wiki formatter migration)
+    // ========================================================================
+
+    /**
+     * Handle javascript: protocol links from legacy content
+     * @param href - The href attribute value (e.g., "javascript:toggleAll()")
+     */
+    private handleJavaScriptAction(href: string): void {
+        const action = href.replace('javascript:', '').replace(/\(\).*$/, '');
+
+        switch (action) {
+            case 'toggleAll':
+                this.toggleAll();
+                break;
+            case 'toggleRus':
+                this.toggleRus();
+                break;
+            case 'toggleCsl':
+                this.toggleCsl();
+                break;
+            default:
+                this.logger.warn('Unknown javascript action', { action, href });
+                break;
+        }
+    }
+
+    /**
+     * Toggle visibility of all comments
+     * Mimics jQuery: toggleAll() function
+     */
+    private toggleAll(): void {
+        const host = this.elementRef.nativeElement;
+        const comments = host.querySelectorAll('.cmnt');
+        const links = Array.from(
+            host.querySelectorAll('.LinkComment')
+        ) as HTMLElement[];
+
+        // Check current state from first link
+        const isExpanded = links[0]?.textContent?.trim() === 'Свернуть';
+
+        // Update all toggle links
+        links.forEach(link => {
+            link.textContent = isExpanded ? 'Развернуть' : 'Свернуть';
+        });
+
+        // Toggle comments visibility
+        comments.forEach((comment: Element) => {
+            (comment as HTMLElement).style.display = isExpanded ? 'none' : '';
+        });
+
+        // Update state
+        this.interactionState.commentsExpanded = !isExpanded;
+    }
+
+    /**
+     * Toggle visibility of Russian translation
+     * Mimics jQuery: toggleRus() function
+     */
+    private toggleRus(): void {
+        const host = this.elementRef.nativeElement;
+        const rusElements = Array.from(
+            host.querySelectorAll('.BibleRus')
+        ) as HTMLElement[];
+        const cslElements = Array.from(
+            host.querySelectorAll('.BibleCsl')
+        ) as HTMLElement[];
+
+        // Toggle Russian elements
+        const willBeHidden = rusElements[0]?.style.display !== 'none';
+        rusElements.forEach(el => {
+            el.style.display = willBeHidden ? 'none' : '';
+        });
+
+        // If hiding Russian, ensure Church Slavonic is visible
+        if (willBeHidden) {
+            cslElements.forEach(el => {
+                el.style.display = '';
+            });
+            this.interactionState.cslVisible = true;
+        }
+
+        // Update state and links
+        this.interactionState.rusVisible = !willBeHidden;
+        this.updateBibleLinks();
+    }
+
+    /**
+     * Toggle visibility of Church Slavonic translation
+     * Mimics jQuery: toggleCsl() function
+     */
+    private toggleCsl(): void {
+        const host = this.elementRef.nativeElement;
+        const cslElements = Array.from(
+            host.querySelectorAll('.BibleCsl')
+        ) as HTMLElement[];
+        const rusElements = Array.from(
+            host.querySelectorAll('.BibleRus')
+        ) as HTMLElement[];
+
+        // Toggle Church Slavonic elements
+        const willBeHidden = cslElements[0]?.style.display !== 'none';
+        cslElements.forEach(el => {
+            el.style.display = willBeHidden ? 'none' : '';
+        });
+
+        // If hiding Church Slavonic, ensure Russian is visible
+        if (willBeHidden) {
+            rusElements.forEach(el => {
+                el.style.display = '';
+            });
+            this.interactionState.rusVisible = true;
+        }
+
+        // Update state and links
+        this.interactionState.cslVisible = !willBeHidden;
+        this.updateBibleLinks();
+    }
+
+    /**
+     * Toggle visibility of elements by class name
+     * Mimics jQuery: toggleGroup(cl) function
+     */
+    private toggleGroup(className: string): void {
+        const host = this.elementRef.nativeElement;
+        const elements = Array.from(
+            host.querySelectorAll(`.${className}`)
+        ) as HTMLElement[];
+
+        elements.forEach(el => {
+            el.style.display = el.style.display === 'none' ? '' : 'none';
+        });
+    }
+
+    /**
+     * Update text of Bible translation toggle links
+     * Mimics jQuery: checkBibleLinks() function
+     */
+    private updateBibleLinks(): void {
+        const host = this.elementRef.nativeElement;
+        const rusLinks = Array.from(
+            host.querySelectorAll('.toggleRus')
+        ) as HTMLElement[];
+        const cslLinks = Array.from(
+            host.querySelectorAll('.toggleCsl')
+        ) as HTMLElement[];
+
+        const rusText = this.interactionState.rusVisible
+            ? 'Скрыть русский перевод'
+            : 'Показать русский перевод';
+        const cslText = this.interactionState.cslVisible
+            ? 'Скрыть церковнославянский перевод'
+            : 'Показать церковнославянский перевод';
+
+        rusLinks.forEach(link => {
+            link.textContent = rusText;
+        });
+
+        cslLinks.forEach(link => {
+            link.textContent = cslText;
+        });
     }
 }

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -370,7 +370,7 @@ export class ArticleContentComponent implements OnInit, OnDestroy {
     private toggleGroup(className: string): void {
         const host = this.elementRef.nativeElement;
         const elements = Array.from(
-            host.querySelectorAll(`.${className}`)
+            host.querySelectorAll(`.${CSS.escape(className)}`)
         ) as HTMLElement[];
 
         elements.forEach(el => {

--- a/libs/ui/src/lib/styles/_theme-colors.scss
+++ b/libs/ui/src/lib/styles/_theme-colors.scss
@@ -85,8 +85,7 @@ $theme-colors: (
     ),
 
     // wiki colors
-    // footnotes and other links by default
-    wiki-default-link: (
+    wiki-note-link: (
             light: $md-brown-600,
             dark: $md-brown-300,
         ),


### PR DESCRIPTION
…e themed link styling

- Implement handling for legacy `javascript:` actions (e.g., `toggleAll`, `toggleRus`, `toggleCsl`) in `ArticleContentComponent`.
- Add unit tests to ensure functionality and prevent regressions.
- Update `_theme-colors.scss` and CSS to enhance wiki link styling with specific themes for `note` and `source` links.