### PR TITLE
feat(article): add article version save functionality

### DIFF
--- a/apps/client-e2e/playwright.config.ts
+++ b/apps/client-e2e/playwright.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, devices } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { defineConfig, devices } from '@playwright/test';
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';

--- a/apps/client-e2e/src/fixtures/auth.fixture.ts
+++ b/apps/client-e2e/src/fixtures/auth.fixture.ts
@@ -21,9 +21,9 @@
  * ```
  */
 
-import { test as base, Page, Route } from '@playwright/test';
-import { User } from '@drevo-web/shared';
 import { apiPatterns, authResponses, mockUsers } from './api-mocks';
+import { User } from '@drevo-web/shared';
+import { test as base, Page, Route } from '@playwright/test';
 
 // ============================================================================
 // Types

--- a/apps/client/src/app/app.component.spec.ts
+++ b/apps/client/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {

--- a/apps/client/src/app/app.component.ts
+++ b/apps/client/src/app/app.component.ts
@@ -1,14 +1,14 @@
+import { LayoutComponent } from './layout/layout.component';
 import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import {
     ActivatedRoute,
     NavigationEnd,
     Router,
     RouterModule,
 } from '@angular/router';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { filter, map, startWith } from 'rxjs/operators';
-import { LayoutComponent } from './layout/layout.component';
 import { LoggerService } from '@drevo-web/core';
+import { filter, map, startWith } from 'rxjs/operators';
 
 @Component({
     imports: [RouterModule, LayoutComponent],

--- a/apps/client/src/app/app.config.browser.ts
+++ b/apps/client/src/app/app.config.browser.ts
@@ -1,3 +1,4 @@
+import { environment } from '../environments/environment';
 import {
     ApplicationConfig,
     ErrorHandler,
@@ -6,7 +7,6 @@ import {
 } from '@angular/core';
 import { Router } from '@angular/router';
 import * as Sentry from '@sentry/angular';
-import { environment } from '../environments/environment';
 
 /**
  * Browser-specific configuration that should NOT be included in SSR.

--- a/apps/client/src/app/app.config.server.ts
+++ b/apps/client/src/app/app.config.server.ts
@@ -1,7 +1,7 @@
-import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
-import { provideServerRendering, withRoutes } from '@angular/ssr';
 import { appConfig } from './app.config';
 import { serverRoutes } from './app.routes.server';
+import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { provideServerRendering, withRoutes } from '@angular/ssr';
 
 const serverConfig: ApplicationConfig = {
     providers: [provideServerRendering(withRoutes(serverRoutes))],

--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -1,24 +1,25 @@
+import { appRoutes } from './app.routes';
+import { environment } from '../environments/environment';
+import { authInterceptorProvider } from './interceptors/auth.interceptor';
+import {
+    provideHttpClient,
+    withFetch,
+    withInterceptorsFromDi,
+} from '@angular/common/http';
 import {
     ApplicationConfig,
     importProvidersFrom,
     provideZonelessChangeDetection,
 } from '@angular/core';
 import {
-    provideRouter,
-    RouterModule,
-    withComponentInputBinding,
-} from '@angular/router';
-import { appRoutes } from './app.routes';
-import {
     provideClientHydration,
     withEventReplay,
 } from '@angular/platform-browser';
 import {
-    provideHttpClient,
-    withFetch,
-    withInterceptorsFromDi,
-} from '@angular/common/http';
-import { authInterceptorProvider } from './interceptors/auth.interceptor';
+    provideRouter,
+    RouterModule,
+    withComponentInputBinding,
+} from '@angular/router';
 import {
     errorNotificationInterceptorProvider,
     provideLogProductionMode,
@@ -26,7 +27,8 @@ import {
     createIndexedDBLogProvider,
     createSentryLogProvider,
 } from '@drevo-web/core';
-import { environment } from '../environments/environment';
+
+
 
 const routesTracing = false;
 

--- a/apps/client/src/app/app.config.ts
+++ b/apps/client/src/app/app.config.ts
@@ -28,8 +28,6 @@ import {
     createSentryLogProvider,
 } from '@drevo-web/core';
 
-
-
 const routesTracing = false;
 
 // Build log providers array based on environment

--- a/apps/client/src/app/app.routes.ts
+++ b/apps/client/src/app/app.routes.ts
@@ -1,5 +1,5 @@
-import { Route } from '@angular/router';
 import { authGuard } from './guards/auth.guard';
+import { Route } from '@angular/router';
 
 export const appRoutes: Route[] = [
     {

--- a/apps/client/src/app/components/auth-status/auth-status.component.spec.ts
+++ b/apps/client/src/app/components/auth-status/auth-status.component.spec.ts
@@ -5,8 +5,6 @@ import { User } from '@drevo-web/shared';
 import { AuthService } from '../../services/auth/auth.service';
 import { AuthStatusComponent } from './auth-status.component';
 
-
-
 describe('AuthStatusComponent', () => {
     let spectator: Spectator<AuthStatusComponent>;
     let userSubject: BehaviorSubject<User | undefined>;

--- a/apps/client/src/app/components/auth-status/auth-status.component.spec.ts
+++ b/apps/client/src/app/components/auth-status/auth-status.component.spec.ts
@@ -1,9 +1,11 @@
+import { provideRouter } from '@angular/router';
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { BehaviorSubject, of, throwError } from 'rxjs';
-import { provideRouter } from '@angular/router';
-import { AuthStatusComponent } from './auth-status.component';
-import { AuthService } from '../../services/auth/auth.service';
 import { User } from '@drevo-web/shared';
+import { AuthService } from '../../services/auth/auth.service';
+import { AuthStatusComponent } from './auth-status.component';
+
+
 
 describe('AuthStatusComponent', () => {
     let spectator: Spectator<AuthStatusComponent>;

--- a/apps/client/src/app/components/auth-status/auth-status.component.ts
+++ b/apps/client/src/app/components/auth-status/auth-status.component.ts
@@ -1,9 +1,9 @@
-import { Component, DestroyRef, inject } from '@angular/core';
+import { AuthService } from '../../services/auth/auth.service';
 import { AsyncPipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
-import { AuthService } from '../../services/auth/auth.service';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { finalize } from 'rxjs/operators';
 
 @Component({

--- a/apps/client/src/app/components/theme-toggle/theme-toggle.component.spec.ts
+++ b/apps/client/src/app/components/theme-toggle/theme-toggle.component.spec.ts
@@ -1,6 +1,6 @@
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
-import { ThemeToggleComponent } from './theme-toggle.component';
 import { ThemeService } from '../../services/theme/theme.service';
+import { ThemeToggleComponent } from './theme-toggle.component';
 
 describe('ThemeToggleComponent', () => {
     let spectator: Spectator<ThemeToggleComponent>;

--- a/apps/client/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/apps/client/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -1,6 +1,6 @@
+import { ThemeService } from '../../services/theme/theme.service';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { IconButtonComponent } from '@drevo-web/ui';
-import { ThemeService } from '../../services/theme/theme.service';
 
 @Component({
     selector: 'app-theme-toggle',

--- a/apps/client/src/app/components/version-display/version-display.component.spec.ts
+++ b/apps/client/src/app/components/version-display/version-display.component.spec.ts
@@ -1,7 +1,6 @@
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
-
-import { VersionDisplayComponent } from './version-display.component';
 import { VersionService } from '../../services/version/version.service';
+import { VersionDisplayComponent } from './version-display.component';
 
 describe('VersionDisplayComponent', () => {
     let spectator: Spectator<VersionDisplayComponent>;

--- a/apps/client/src/app/components/version-display/version-display.component.ts
+++ b/apps/client/src/app/components/version-display/version-display.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { VersionService } from '../../services/version/version.service';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
 @Component({
     selector: 'app-version-display',

--- a/apps/client/src/app/guards/auth.guard.spec.ts
+++ b/apps/client/src/app/guards/auth.guard.spec.ts
@@ -1,19 +1,19 @@
-import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
-import {
-    ActivatedRouteSnapshot,
-    Router,
-    RouterStateSnapshot,
-    UrlTree,
-} from '@angular/router';
 import {
     PLATFORM_ID,
     EnvironmentInjector,
     runInInjectionContext,
     Injectable,
 } from '@angular/core';
+import {
+    ActivatedRouteSnapshot,
+    Router,
+    RouterStateSnapshot,
+    UrlTree,
+} from '@angular/router';
+import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
 import { BehaviorSubject, isObservable, firstValueFrom } from 'rxjs';
-import { authGuard } from './auth.guard';
 import { AuthService } from '../services/auth/auth.service';
+import { authGuard } from './auth.guard';
 
 /**
  * Dummy service to bootstrap Spectator's injection context

--- a/apps/client/src/app/guards/auth.guard.ts
+++ b/apps/client/src/app/guards/auth.guard.ts
@@ -1,10 +1,10 @@
-import { inject, PLATFORM_ID } from '@angular/core';
+import { AuthService } from '../services/auth/auth.service';
 import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
 import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { isValidReturnUrl } from '@drevo-web/shared';
 import { Observable } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
-import { AuthService } from '../services/auth/auth.service';
-import { isValidReturnUrl } from '@drevo-web/shared';
 
 export const authGuard: CanActivateFn = (
     _route,

--- a/apps/client/src/app/interceptors/auth.interceptor.spec.ts
+++ b/apps/client/src/app/interceptors/auth.interceptor.spec.ts
@@ -1,17 +1,17 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import {
     HttpRequest,
     HttpHandler,
     HttpResponse,
     HttpErrorResponse,
 } from '@angular/common/http';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { of, throwError, Subject, BehaviorSubject } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { AuthInterceptor, authInterceptorProvider } from './auth.interceptor';
-import { AuthService } from '../services/auth/auth.service';
-import { CsrfService } from '../services/auth/csrf.service';
 import { LoggerService } from '@drevo-web/core';
 import { mockLoggerProvider, MockLoggerService } from '@drevo-web/core/testing';
+import { AuthService } from '../services/auth/auth.service';
+import { CsrfService } from '../services/auth/csrf.service';
+import { AuthInterceptor, authInterceptorProvider } from './auth.interceptor';
 
 jest.mock('../../environments/environment', () => ({
     environment: { apiUrl: 'http://test-api' },

--- a/apps/client/src/app/interceptors/auth.interceptor.ts
+++ b/apps/client/src/app/interceptors/auth.interceptor.ts
@@ -1,4 +1,6 @@
-import { Injectable, inject, Injector } from '@angular/core';
+import { environment } from '../../environments/environment';
+import { AuthService } from '../services/auth/auth.service';
+import { CsrfService } from '../services/auth/csrf.service';
 import {
     HttpInterceptor,
     HttpRequest,
@@ -7,6 +9,8 @@ import {
     HttpErrorResponse,
     HTTP_INTERCEPTORS,
 } from '@angular/common/http';
+import { Injectable, inject, Injector } from '@angular/core';
+import { LoggerService } from '@drevo-web/core';
 import { Observable, throwError } from 'rxjs';
 import {
     catchError,
@@ -16,10 +20,6 @@ import {
     switchMap,
     take,
 } from 'rxjs/operators';
-import { AuthService } from '../services/auth/auth.service';
-import { CsrfService } from '../services/auth/csrf.service';
-import { LoggerService } from '@drevo-web/core';
-import { environment } from '../../environments/environment';
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
 const CSRF_ENDPOINTS = ['/api/auth/csrf'];

--- a/apps/client/src/app/layout/footer/footer.component.spec.ts
+++ b/apps/client/src/app/layout/footer/footer.component.spec.ts
@@ -1,5 +1,4 @@
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
-
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {

--- a/apps/client/src/app/layout/footer/footer.component.ts
+++ b/apps/client/src/app/layout/footer/footer.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { VersionDisplayComponent } from '../../components/version-display/version-display.component';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 @Component({
     selector: 'app-footer',

--- a/apps/client/src/app/layout/header/header.component.spec.ts
+++ b/apps/client/src/app/layout/header/header.component.spec.ts
@@ -1,11 +1,14 @@
+import { provideRouter } from '@angular/router';
 import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { MockProvider } from 'ng-mocks';
-import { provideRouter } from '@angular/router';
-import { HeaderComponent } from './header.component';
-import { ModalService } from '@drevo-web/ui';
-import { LogExportService } from '@drevo-web/core';
-import { AuthService } from '../../services/auth/auth.service';
 import { of } from 'rxjs';
+import { LogExportService } from '@drevo-web/core';
+import { ModalService } from '@drevo-web/ui';
+import { AuthService } from '../../services/auth/auth.service';
+import { HeaderComponent } from './header.component';
+
+
+
 
 describe('HeaderComponent', () => {
     let spectator: Spectator<HeaderComponent>;

--- a/apps/client/src/app/layout/header/header.component.spec.ts
+++ b/apps/client/src/app/layout/header/header.component.spec.ts
@@ -7,9 +7,6 @@ import { ModalService } from '@drevo-web/ui';
 import { AuthService } from '../../services/auth/auth.service';
 import { HeaderComponent } from './header.component';
 
-
-
-
 describe('HeaderComponent', () => {
     let spectator: Spectator<HeaderComponent>;
     const createComponent = createComponentFactory({

--- a/apps/client/src/app/layout/header/header.component.ts
+++ b/apps/client/src/app/layout/header/header.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AuthStatusComponent } from '../../components/auth-status/auth-status.component';
 import { ThemeToggleComponent } from '../../components/theme-toggle/theme-toggle.component';
-import { IconButtonComponent, ModalService } from '@drevo-web/ui';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { LogExportService } from '@drevo-web/core';
+import { IconButtonComponent, ModalService } from '@drevo-web/ui';
 
 @Component({
     selector: 'app-header',

--- a/apps/client/src/app/layout/layout.component.spec.ts
+++ b/apps/client/src/app/layout/layout.component.spec.ts
@@ -1,8 +1,7 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
-
-import { LayoutComponent } from './layout.component';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import { LayoutComponent } from './layout.component';
 
 describe('LayoutComponent', () => {
     let spectator: Spectator<LayoutComponent>;

--- a/apps/client/src/app/layout/layout.component.ts
+++ b/apps/client/src/app/layout/layout.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { FooterComponent } from './footer/footer.component';
 import { HeaderComponent } from './header/header.component';
-import { RightSidebarComponent } from '@drevo-web/ui';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { SidebarService } from '@drevo-web/core';
+import { RightSidebarComponent } from '@drevo-web/ui';
 
 @Component({
     selector: 'app-layout',

--- a/apps/client/src/app/models/apis/article.api.ts
+++ b/apps/client/src/app/models/apis/article.api.ts
@@ -1,5 +1,5 @@
-import { Observable } from 'rxjs';
 import { Article } from '@drevo-web/shared';
+import { Observable } from 'rxjs';
 
 export interface ArticleApi {
     getArticle: () => Observable<Article>;

--- a/apps/client/src/app/pages/article-edit/article-edit.component.html
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.html
@@ -7,6 +7,23 @@
         title="Ошибка"
         [message]="error()" />
 } @else if (version(); as version) {
+    <button
+        sidebarAction
+        icon="save"
+        priority="primary"
+        [disabled]="isSaving()"
+        (click)="save()">
+        Сохранить
+    </button>
+    <button
+        sidebarAction
+        icon="close"
+        priority="secondary"
+        [disabled]="isSaving()"
+        (click)="cancel()">
+        Отмена
+    </button>
+
     <div class="article-edit">
         <header class="article-edit-header">
             <h1 class="article-edit-title">{{ version.title }}</h1>

--- a/apps/client/src/app/pages/article-edit/article-edit.component.spec.ts
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.spec.ts
@@ -1,14 +1,17 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
-import { ArticleVersion } from '@drevo-web/shared';
+import { NotificationService } from '@drevo-web/core';
+import { ArticleVersion, SaveArticleVersionResult } from '@drevo-web/shared';
 import { ArticleService } from '../../services/articles';
 import { ArticleEditComponent } from './article-edit.component';
 
 describe('ArticleEditComponent', () => {
     let spectator: Spectator<ArticleEditComponent>;
     let articleService: jest.Mocked<ArticleService>;
+    let notificationService: jest.Mocked<NotificationService>;
+    let router: jest.Mocked<Router>;
     let paramMapSubject: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
 
     const mockVersion: ArticleVersion = {
@@ -26,7 +29,7 @@ describe('ArticleEditComponent', () => {
 
     const createComponent = createComponentFactory({
         component: ArticleEditComponent,
-        mocks: [ArticleService],
+        mocks: [ArticleService, NotificationService, Router],
         providers: [
             {
                 provide: ActivatedRoute,
@@ -44,6 +47,10 @@ describe('ArticleEditComponent', () => {
         articleService = spectator.inject(
             ArticleService
         ) as jest.Mocked<ArticleService>;
+        notificationService = spectator.inject(
+            NotificationService
+        ) as jest.Mocked<NotificationService>;
+        router = spectator.inject(Router) as jest.Mocked<Router>;
         articleService.getArticleVersion.mockReturnValue(of(mockVersion));
     });
 
@@ -223,6 +230,230 @@ describe('ArticleEditComponent', () => {
             expect(() => {
                 spectator.component.contentChanged('new content');
             }).not.toThrow();
+        });
+    });
+
+    describe('save method', () => {
+        const mockSaveResult: SaveArticleVersionResult = {
+            articleId: 123,
+            versionId: 999,
+            title: 'Test Article Title',
+            author: 'Test Author',
+            date: new Date('2024-01-15T10:00:00Z'),
+            approved: 0,
+        };
+
+        beforeEach(() => {
+            articleService.saveArticleVersion.mockReturnValue(of(mockSaveResult));
+        });
+
+        it('should not save when version is undefined', () => {
+            spectator.component.save();
+
+            expect(articleService.saveArticleVersion).not.toHaveBeenCalled();
+        });
+
+        it('should not save when already saving', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            articleService.saveArticleVersion.mockReturnValue(NEVER);
+            spectator.component.save();
+            spectator.component.save();
+
+            expect(articleService.saveArticleVersion).toHaveBeenCalledTimes(1);
+        });
+
+        it('should show info notification when content has not changed', () => {
+            spectator.detectChanges();
+
+            spectator.component.save();
+
+            expect(notificationService.info).toHaveBeenCalledWith(
+                'Нет изменений для сохранения'
+            );
+            expect(articleService.saveArticleVersion).not.toHaveBeenCalled();
+        });
+
+        it('should save when content has changed', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            spectator.component.save();
+
+            expect(articleService.saveArticleVersion).toHaveBeenCalledWith({
+                versionId: 456,
+                content: 'new content',
+            });
+        });
+
+        it('should set isSaving to true while saving', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+            articleService.saveArticleVersion.mockReturnValue(NEVER);
+
+            spectator.component.save();
+
+            expect(spectator.component.isSaving()).toBe(true);
+        });
+
+        it('should navigate to article page on successful save', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            spectator.component.save();
+
+            expect(router.navigate).toHaveBeenCalledWith(['/articles', 123]);
+        });
+
+        it('should show success notification on successful save', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            spectator.component.save();
+
+            expect(notificationService.success).toHaveBeenCalledWith(
+                'Статья сохранена'
+            );
+        });
+
+        it('should set isSaving to false after successful save', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            spectator.component.save();
+
+            expect(spectator.component.isSaving()).toBe(false);
+        });
+
+        it('should show error notification on 401 error', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 401,
+                statusText: 'Unauthorized',
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(notificationService.error).toHaveBeenCalledWith(
+                'Необходима авторизация'
+            );
+        });
+
+        it('should show error notification on 403 error', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 403,
+                statusText: 'Forbidden',
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(notificationService.error).toHaveBeenCalledWith(
+                'Нет прав для сохранения'
+            );
+        });
+
+        it('should show custom error message from 403 response', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 403,
+                statusText: 'Forbidden',
+                error: { error: 'Статья заблокирована' },
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(notificationService.error).toHaveBeenCalledWith(
+                'Статья заблокирована'
+            );
+        });
+
+        it('should show generic error message on other errors', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 500,
+                statusText: 'Server Error',
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(notificationService.error).toHaveBeenCalledWith(
+                'Ошибка сохранения'
+            );
+        });
+
+        it('should show error message from response body', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 500,
+                statusText: 'Server Error',
+                error: { error: 'Внутренняя ошибка сервера' },
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(notificationService.error).toHaveBeenCalledWith(
+                'Внутренняя ошибка сервера'
+            );
+        });
+
+        it('should set isSaving to false after error', () => {
+            spectator.detectChanges();
+            spectator.component.contentChanged('new content');
+
+            const error = new HttpErrorResponse({
+                status: 500,
+                statusText: 'Server Error',
+            });
+            articleService.saveArticleVersion.mockReturnValue(
+                throwError(() => error)
+            );
+
+            spectator.component.save();
+
+            expect(spectator.component.isSaving()).toBe(false);
+        });
+    });
+
+    describe('cancel method', () => {
+        it('should navigate to article page when version exists', () => {
+            spectator.detectChanges();
+
+            spectator.component.cancel();
+
+            expect(router.navigate).toHaveBeenCalledWith(['/articles', 123]);
+        });
+
+        it('should navigate to home when version is undefined', () => {
+            spectator.component.cancel();
+
+            expect(router.navigate).toHaveBeenCalledWith(['/']);
         });
     });
 });

--- a/apps/client/src/app/pages/article-edit/article-edit.component.spec.ts
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.spec.ts
@@ -1,10 +1,10 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
-import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ArticleEditComponent } from './article-edit.component';
-import { ArticleService } from '../../services/articles';
+import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
 import { ArticleVersion } from '@drevo-web/shared';
+import { ArticleService } from '../../services/articles';
+import { ArticleEditComponent } from './article-edit.component';
 
 describe('ArticleEditComponent', () => {
     let spectator: Spectator<ArticleEditComponent>;

--- a/apps/client/src/app/pages/article-edit/article-edit.component.ts
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.ts
@@ -1,3 +1,7 @@
+import { ArticleService } from '../../services/articles';
+import { ErrorComponent } from '../error/error.component';
+import { AsyncPipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -7,21 +11,17 @@ import {
     signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute } from '@angular/router';
-import { distinctUntilChanged, map } from 'rxjs/operators';
-import { BehaviorSubject } from 'rxjs';
-import { AsyncPipe } from '@angular/common';
-
+import { ActivatedRoute , Router } from '@angular/router';
+import { NotificationService , LoggerService } from '@drevo-web/core';
 import { EditorComponent } from '@drevo-web/editor';
-import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
-import { ErrorComponent } from '../error/error.component';
-import { Router } from '@angular/router';
 import { ArticleVersion } from '@drevo-web/shared';
-import { NotificationService } from '@drevo-web/core';
-import { ArticleService } from '../../services/articles';
+import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
+import { BehaviorSubject } from 'rxjs';
+import { distinctUntilChanged, map } from 'rxjs/operators';
+
+
 // import { LinksService } from '../../services/links/links.service';
-import { LoggerService } from '@drevo-web/core';
-import { HttpErrorResponse } from '@angular/common/http';
+
 
 @Component({
     selector: 'app-article-edit',

--- a/apps/client/src/app/pages/article-edit/article-edit.component.ts
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.ts
@@ -13,9 +13,11 @@ import { BehaviorSubject } from 'rxjs';
 import { AsyncPipe } from '@angular/common';
 
 import { EditorComponent } from '@drevo-web/editor';
-import { SpinnerComponent } from '@drevo-web/ui';
+import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
 import { ErrorComponent } from '../error/error.component';
+import { Router } from '@angular/router';
 import { ArticleVersion } from '@drevo-web/shared';
+import { NotificationService } from '@drevo-web/core';
 import { ArticleService } from '../../services/articles';
 // import { LinksService } from '../../services/links/links.service';
 import { LoggerService } from '@drevo-web/core';
@@ -23,7 +25,13 @@ import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
     selector: 'app-article-edit',
-    imports: [EditorComponent, SpinnerComponent, AsyncPipe, ErrorComponent],
+    imports: [
+        EditorComponent,
+        SpinnerComponent,
+        AsyncPipe,
+        ErrorComponent,
+        SidebarActionDirective,
+    ],
     // providers: [LinksService],
     templateUrl: './article-edit.component.html',
     styleUrl: './article-edit.component.scss',
@@ -31,12 +39,16 @@ import { HttpErrorResponse } from '@angular/common/http';
 })
 export class ArticleEditComponent implements OnInit {
     private readonly route = inject(ActivatedRoute);
+    private readonly router = inject(Router);
     private readonly articleService = inject(ArticleService);
+    private readonly notificationService = inject(NotificationService);
     // private readonly linksService = inject(LinksService);
     private readonly destroyRef = inject(DestroyRef);
     private readonly logger = inject(LoggerService).withContext(
         'ArticleEditComponent'
     );
+
+    private currentContent: string | undefined = undefined;
 
     private readonly updateLinksStateSubject = new BehaviorSubject<
         Record<string, boolean>
@@ -44,6 +56,7 @@ export class ArticleEditComponent implements OnInit {
 
     readonly version = signal<ArticleVersion | undefined>(undefined);
     readonly isLoading = signal<boolean>(false);
+    readonly isSaving = signal<boolean>(false);
     readonly error = signal<string | undefined>(undefined);
     readonly updateLinksState$ = this.updateLinksStateSubject.asObservable();
 
@@ -112,6 +125,71 @@ export class ArticleEditComponent implements OnInit {
     }
 
     contentChanged(content: string): void {
+        this.currentContent = content;
         this.logger.debug('Content changed', { length: content.length });
+    }
+
+    save(): void {
+        const version = this.version();
+        if (!version || this.isSaving()) {
+            return;
+        }
+
+        const content = this.currentContent ?? version.content;
+
+        if (content === version.content) {
+            this.notificationService.info('Нет изменений для сохранения');
+            return;
+        }
+
+        this.isSaving.set(true);
+        this.logger.info('Saving article', {
+            versionId: version.versionId,
+            articleId: version.articleId,
+            contentLength: content.length,
+        });
+
+        this.articleService
+            .saveArticleVersion({
+                versionId: version.versionId,
+                content,
+            })
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: result => {
+                    this.isSaving.set(false);
+                    this.logger.info('Article saved', {
+                        newVersionId: result.versionId,
+                        articleId: result.articleId,
+                    });
+                    this.notificationService.success('Статья сохранена');
+                    this.router.navigate(['/articles', result.articleId]);
+                },
+                error: (err: HttpErrorResponse) => {
+                    this.isSaving.set(false);
+                    this.logger.error('Failed to save article', err);
+
+                    let errorMessage = 'Ошибка сохранения';
+                    if (err.status === 401) {
+                        errorMessage = 'Необходима авторизация';
+                    } else if (err.status === 403) {
+                        errorMessage =
+                            err.error?.error || 'Нет прав для сохранения';
+                    } else if (err.error?.error) {
+                        errorMessage = err.error.error;
+                    }
+
+                    this.notificationService.error(errorMessage);
+                },
+            });
+    }
+
+    cancel(): void {
+        const version = this.version();
+        if (version) {
+            this.router.navigate(['/articles', version.articleId]);
+        } else {
+            this.router.navigate(['/']);
+        }
     }
 }

--- a/apps/client/src/app/pages/article-edit/article-edit.component.ts
+++ b/apps/client/src/app/pages/article-edit/article-edit.component.ts
@@ -11,17 +11,14 @@ import {
     signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { ActivatedRoute , Router } from '@angular/router';
-import { NotificationService , LoggerService } from '@drevo-web/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NotificationService, LoggerService } from '@drevo-web/core';
 import { EditorComponent } from '@drevo-web/editor';
 import { ArticleVersion } from '@drevo-web/shared';
 import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
 import { BehaviorSubject } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
-
-
 // import { LinksService } from '../../services/links/links.service';
-
 
 @Component({
     selector: 'app-article-edit',

--- a/apps/client/src/app/pages/article/article-content/article-content.component.ts
+++ b/apps/client/src/app/pages/article/article-content/article-content.component.ts
@@ -8,8 +8,8 @@ import {
     OnInit,
     ViewEncapsulation,
 } from '@angular/core';
-import { Router } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { LoggerService, NotificationService } from '@drevo-web/core';
 
 /**

--- a/apps/client/src/app/pages/article/article.component.spec.ts
+++ b/apps/client/src/app/pages/article/article.component.spec.ts
@@ -1,10 +1,10 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
-import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ArticleComponent } from './article.component';
-import { ArticleService } from '../../services/articles';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { of, throwError, NEVER, BehaviorSubject } from 'rxjs';
 import { Article } from '@drevo-web/shared';
+import { ArticleService } from '../../services/articles';
+import { ArticleComponent } from './article.component';
 
 describe('ArticleComponent', () => {
     let spectator: Spectator<ArticleComponent>;

--- a/apps/client/src/app/pages/article/article.component.ts
+++ b/apps/client/src/app/pages/article/article.component.ts
@@ -1,3 +1,7 @@
+import { ArticleService } from '../../services/articles';
+import { ErrorComponent } from '../error/error.component';
+import { ArticleContentComponent } from './article-content/article-content.component';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
     afterNextRender,
     ChangeDetectionStrategy,
@@ -10,16 +14,11 @@ import {
     signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
 import { ActivatedRoute } from '@angular/router';
-import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
-import { ErrorComponent } from '../error/error.component';
-import { ArticleVersion } from '@drevo-web/shared';
-import { ArticleService } from '../../services/articles';
-import { HttpErrorResponse } from '@angular/common/http';
-import { distinctUntilChanged, map } from 'rxjs/operators';
 import { LoggerService } from '@drevo-web/core';
-import { ArticleContentComponent } from './article-content/article-content.component';
+import { ArticleVersion } from '@drevo-web/shared';
+import { SpinnerComponent, SidebarActionDirective } from '@drevo-web/ui';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 @Component({
     selector: 'app-article',

--- a/apps/client/src/app/pages/error/error.component.spec.ts
+++ b/apps/client/src/app/pages/error/error.component.spec.ts
@@ -1,5 +1,5 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { provideRouter } from '@angular/router';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { ErrorComponent } from './error.component';
 
 describe('ErrorComponent', () => {

--- a/apps/client/src/app/pages/login/login.component.spec.ts
+++ b/apps/client/src/app/pages/login/login.component.spec.ts
@@ -1,16 +1,16 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { PLATFORM_ID } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { ActivatedRoute, Router } from '@angular/router';
-import { of, throwError } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { LoginComponent } from './login.component';
-import { AuthService } from '../../services/auth/auth.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
+import { of, throwError } from 'rxjs';
 import {
     TextInputComponent,
     CheckboxComponent,
     ButtonComponent,
 } from '@drevo-web/ui';
+import { AuthService } from '../../services/auth/auth.service';
+import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
     let spectator: Spectator<LoginComponent>;

--- a/apps/client/src/app/pages/login/login.component.ts
+++ b/apps/client/src/app/pages/login/login.component.ts
@@ -1,3 +1,5 @@
+import { AuthService } from '../../services/auth/auth.service';
+import { isPlatformBrowser } from '@angular/common';
 import {
     Component,
     signal,
@@ -7,7 +9,7 @@ import {
     OnInit,
     ChangeDetectionStrategy,
 } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
     FormControl,
     FormGroup,
@@ -15,15 +17,13 @@ import {
     Validators,
 } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AuthService } from '../../services/auth/auth.service';
-import { finalize } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { isValidReturnUrl } from '@drevo-web/shared';
 import {
     TextInputComponent,
     CheckboxComponent,
     ButtonComponent,
 } from '@drevo-web/ui';
+import { finalize } from 'rxjs';
 
 @Component({
     selector: 'app-login',

--- a/apps/client/src/app/pages/search/search.component.spec.ts
+++ b/apps/client/src/app/pages/search/search.component.spec.ts
@@ -1,9 +1,9 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { provideRouter } from '@angular/router';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { delay, of, throwError } from 'rxjs';
+import { MODAL_DATA, ModalData } from '@drevo-web/ui';
 import { ArticleService } from '../../services/articles';
 import { SearchComponent } from './search.component';
-import { MODAL_DATA, ModalData } from '@drevo-web/ui';
 
 const DEBOUNCE_TIME_MS = 500;
 

--- a/apps/client/src/app/pages/search/search.component.ts
+++ b/apps/client/src/app/pages/search/search.component.ts
@@ -1,3 +1,4 @@
+import { ArticleService } from '../../services/articles';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -8,8 +9,8 @@ import {
     signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-
 import { RouterLink } from '@angular/router';
+import { ArticleSearchResult } from '@drevo-web/shared';
 import {
     SpinnerComponent,
     TextInputComponent,
@@ -19,7 +20,6 @@ import {
     MODAL_DATA,
     ModalData,
 } from '@drevo-web/ui';
-import { ArticleSearchResult } from '@drevo-web/shared';
 import {
     catchError,
     debounceTime,
@@ -31,7 +31,6 @@ import {
     switchMap,
     tap,
 } from 'rxjs';
-import { ArticleService } from '../../services/articles';
 
 const DEBOUNCE_TIME_MS = 500;
 

--- a/apps/client/src/app/pages/shared-editor/shared-editor.component.spec.ts
+++ b/apps/client/src/app/pages/shared-editor/shared-editor.component.spec.ts
@@ -1,11 +1,10 @@
+import { HttpHandler } from '@angular/common/http';
 import {
     Spectator,
     createComponentFactory,
     mockProvider,
 } from '@ngneat/spectator/jest';
-
 import { SharedEditorComponent } from './shared-editor.component';
-import { HttpHandler } from '@angular/common/http';
 
 describe('SharedEditorComponent', () => {
     let spectator: Spectator<SharedEditorComponent>;

--- a/apps/client/src/app/pages/shared-editor/shared-editor.component.ts
+++ b/apps/client/src/app/pages/shared-editor/shared-editor.component.ts
@@ -14,9 +14,6 @@ import { EditorComponent } from '@drevo-web/editor';
 import { InsertTagCommand } from '@drevo-web/shared';
 import { BehaviorSubject, first, Observable, Subject, map } from 'rxjs';
 
-
-
-
 interface EditorConfig {
     content: string;
 }

--- a/apps/client/src/app/pages/shared-editor/shared-editor.component.ts
+++ b/apps/client/src/app/pages/shared-editor/shared-editor.component.ts
@@ -1,3 +1,7 @@
+import { IframeService } from '../../services/iframe/iframe.service';
+import { LinksService } from '../../services/links/links.service';
+import { AsyncPipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -5,14 +9,13 @@ import {
     DestroyRef,
     inject,
 } from '@angular/core';
-import { EditorComponent } from '@drevo-web/editor';
-import { BehaviorSubject, first, Observable, Subject, map } from 'rxjs';
-import { AsyncPipe } from '@angular/common';
-import { IframeService } from '../../services/iframe/iframe.service';
-import { LinksService } from '../../services/links/links.service';
-import { HttpClient } from '@angular/common/http';
-import { InsertTagCommand } from '@drevo-web/shared';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { EditorComponent } from '@drevo-web/editor';
+import { InsertTagCommand } from '@drevo-web/shared';
+import { BehaviorSubject, first, Observable, Subject, map } from 'rxjs';
+
+
+
 
 interface EditorConfig {
     content: string;

--- a/apps/client/src/app/services/articles/article-api.service.spec.ts
+++ b/apps/client/src/app/services/articles/article-api.service.spec.ts
@@ -1,9 +1,9 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideHttpClient } from '@angular/common/http';
 import {
     HttpTestingController,
     provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { ArticleApiService } from './article-api.service';
 
 describe('ArticleApiService', () => {

--- a/apps/client/src/app/services/articles/article-api.service.spec.ts
+++ b/apps/client/src/app/services/articles/article-api.service.spec.ts
@@ -258,6 +258,129 @@ describe('ArticleApiService', () => {
         });
     });
 
+    describe('saveArticleVersion', () => {
+        const mockSaveResponse = {
+            success: true,
+            data: {
+                articleId: 123,
+                versionId: 999,
+                title: 'Updated Article',
+                content: 'New content',
+                author: 'Editor',
+                date: '2024-01-20T12:00:00+00:00',
+                approved: 0,
+            },
+        };
+
+        it('should call HTTP POST with correct URL and body', () => {
+            const request = { versionId: 456, content: 'New content' };
+
+            spectator.service.saveArticleVersion(request).subscribe(result => {
+                expect(result).toEqual(mockSaveResponse.data);
+            });
+
+            const req = httpController.expectOne('/api/articles/save');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.withCredentials).toBe(true);
+            expect(req.request.body).toEqual(request);
+            req.flush(mockSaveResponse);
+        });
+
+        it('should include optional info field in request body', () => {
+            const request = {
+                versionId: 456,
+                content: 'New content',
+                info: 'Version info',
+            };
+
+            spectator.service.saveArticleVersion(request).subscribe();
+
+            const req = httpController.expectOne('/api/articles/save');
+            expect(req.request.body).toEqual(request);
+            req.flush(mockSaveResponse);
+        });
+
+        it('should extract data from response wrapper', done => {
+            spectator.service
+                .saveArticleVersion({ versionId: 456, content: 'New content' })
+                .subscribe(result => {
+                    expect(result.articleId).toBe(123);
+                    expect(result.versionId).toBe(999);
+                    expect(result.title).toBe('Updated Article');
+                    expect(result.approved).toBe(0);
+                    done();
+                });
+
+            const req = httpController.expectOne('/api/articles/save');
+            req.flush(mockSaveResponse);
+        });
+
+        it('should throw when response.data is undefined', done => {
+            spectator.service
+                .saveArticleVersion({ versionId: 456, content: 'New content' })
+                .subscribe({
+                    error: (err: Error) => {
+                        expect(err.message).toContain('Response data is undefined');
+                        done();
+                    },
+                });
+
+            const req = httpController.expectOne('/api/articles/save');
+            req.flush({ success: true, data: undefined });
+        });
+
+        it('should propagate HTTP 401 errors', done => {
+            spectator.service
+                .saveArticleVersion({ versionId: 456, content: 'New content' })
+                .subscribe({
+                    error: err => {
+                        expect(err.status).toBe(401);
+                        done();
+                    },
+                });
+
+            const req = httpController.expectOne('/api/articles/save');
+            req.flush(
+                { success: false, error: 'Unauthorized' },
+                { status: 401, statusText: 'Unauthorized' }
+            );
+        });
+
+        it('should propagate HTTP 403 errors', done => {
+            spectator.service
+                .saveArticleVersion({ versionId: 456, content: 'New content' })
+                .subscribe({
+                    error: err => {
+                        expect(err.status).toBe(403);
+                        done();
+                    },
+                });
+
+            const req = httpController.expectOne('/api/articles/save');
+            req.flush(
+                { success: false, error: 'Forbidden' },
+                { status: 403, statusText: 'Forbidden' }
+            );
+        });
+
+        it('should propagate HTTP 500 errors', done => {
+            spectator.service
+                .saveArticleVersion({ versionId: 456, content: 'New content' })
+                .subscribe({
+                    error: err => {
+                        expect(err.status).toBe(500);
+                        done();
+                    },
+                });
+
+            const req = httpController.expectOne('/api/articles/save');
+            req.flush('Server error', {
+                status: 500,
+                statusText: 'Internal Server Error',
+            });
+        });
+    });
+
     describe('error handling', () => {
         it('should throw when response.data is undefined', done => {
             spectator.service.searchArticles('test').subscribe({

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { SKIP_ERROR_NOTIFICATION } from '@drevo-web/core';
 import {
     ApiResponse,
     ArticleSearchResponseDto,
@@ -119,10 +120,12 @@ export class ArticleApiService {
     saveArticleVersion(
         request: SaveArticleVersionRequestDto
     ): Observable<SaveArticleVersionResponseDto> {
+        const context = new HttpContext().set(SKIP_ERROR_NOTIFICATION, true);
+
         return this.http
             .post<
                 ApiResponse<SaveArticleVersionResponseDto>
-            >(`${this.apiUrl}/api/articles/save`, request, { withCredentials: true })
+            >(`${this.apiUrl}/api/articles/save`, request, { withCredentials: true, context })
             .pipe(
                 map(response => {
                     assertIsDefined(

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, inject } from '@angular/core';
+import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
+import { environment } from '../../../environments/environment';
 import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Injectable, inject } from '@angular/core';
 import { SKIP_ERROR_NOTIFICATION } from '@drevo-web/core';
 import {
     ApiResponse,
@@ -11,8 +11,8 @@ import {
     SaveArticleVersionResponseDto,
     assertIsDefined,
 } from '@drevo-web/shared';
-import { environment } from '../../../environments/environment';
-import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 /**
  * Low-level API service for article-related HTTP requests.

--- a/apps/client/src/app/services/articles/article-api.service.ts
+++ b/apps/client/src/app/services/articles/article-api.service.ts
@@ -6,6 +6,8 @@ import {
     ApiResponse,
     ArticleSearchResponseDto,
     ArticleVersionDto,
+    SaveArticleVersionRequestDto,
+    SaveArticleVersionResponseDto,
     assertIsDefined,
 } from '@drevo-web/shared';
 import { environment } from '../../../environments/environment';
@@ -97,6 +99,30 @@ export class ArticleApiService {
             .get<
                 ApiResponse<ArticleSearchResponseDto>
             >(`${this.apiUrl}/api/articles/search`, { params, withCredentials: true })
+            .pipe(
+                map(response => {
+                    assertIsDefined(
+                        response.data,
+                        'Response data is undefined'
+                    );
+                    return response.data;
+                })
+            );
+    }
+
+    /**
+     * Save article version
+     *
+     * @param request - Save request with versionId, content, and optional info
+     * @returns Observable with raw API response
+     */
+    saveArticleVersion(
+        request: SaveArticleVersionRequestDto
+    ): Observable<SaveArticleVersionResponseDto> {
+        return this.http
+            .post<
+                ApiResponse<SaveArticleVersionResponseDto>
+            >(`${this.apiUrl}/api/articles/save`, request, { withCredentials: true })
             .pipe(
                 map(response => {
                     assertIsDefined(

--- a/apps/client/src/app/services/articles/article.service.spec.ts
+++ b/apps/client/src/app/services/articles/article.service.spec.ts
@@ -5,8 +5,8 @@ import {
     ArticleVersionDto,
     SaveArticleVersionResponseDto,
 } from '@drevo-web/shared';
-import { ArticleService } from './article.service';
 import { ArticleApiService } from './article-api.service';
+import { ArticleService } from './article.service';
 
 describe('ArticleService', () => {
     let spectator: SpectatorService<ArticleService>;

--- a/apps/client/src/app/services/articles/article.service.spec.ts
+++ b/apps/client/src/app/services/articles/article.service.spec.ts
@@ -1,6 +1,10 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
-import { ArticleSearchResponseDto, ArticleVersionDto } from '@drevo-web/shared';
+import {
+    ArticleSearchResponseDto,
+    ArticleVersionDto,
+    SaveArticleVersionResponseDto,
+} from '@drevo-web/shared';
 import { ArticleService } from './article.service';
 import { ArticleApiService } from './article-api.service';
 
@@ -398,6 +402,115 @@ describe('ArticleService', () => {
                     expect(result.total).toBe(0);
                     done();
                 });
+        });
+    });
+
+    describe('saveArticleVersion', () => {
+        const mockSaveResponse: SaveArticleVersionResponseDto = {
+            articleId: 123,
+            versionId: 999,
+            title: 'Test Article',
+            content: 'Updated content',
+            author: 'Test Author',
+            date: '2024-03-15T12:00:00+00:00',
+            approved: 0,
+        };
+
+        it('should call articleApiService.saveArticleVersion with correct request', () => {
+            articleApiService.saveArticleVersion.mockReturnValue(
+                of(mockSaveResponse)
+            );
+
+            spectator.service
+                .saveArticleVersion({
+                    versionId: 456,
+                    content: 'New content',
+                    info: 'Updated description',
+                })
+                .subscribe();
+
+            expect(articleApiService.saveArticleVersion).toHaveBeenCalledWith({
+                versionId: 456,
+                content: 'New content',
+                info: 'Updated description',
+            });
+        });
+
+        it('should map API response to frontend model', done => {
+            articleApiService.saveArticleVersion.mockReturnValue(
+                of(mockSaveResponse)
+            );
+
+            spectator.service
+                .saveArticleVersion({
+                    versionId: 456,
+                    content: 'New content',
+                })
+                .subscribe(result => {
+                    expect(result.articleId).toBe(123);
+                    expect(result.versionId).toBe(999);
+                    expect(result.title).toBe('Test Article');
+                    expect(result.author).toBe('Test Author');
+                    expect(result.approved).toBe(0);
+                    done();
+                });
+        });
+
+        it('should convert date string to Date object', done => {
+            articleApiService.saveArticleVersion.mockReturnValue(
+                of(mockSaveResponse)
+            );
+
+            spectator.service
+                .saveArticleVersion({
+                    versionId: 456,
+                    content: 'New content',
+                })
+                .subscribe(result => {
+                    expect(result.date).toBeInstanceOf(Date);
+                    expect(result.date.toISOString()).toBe(
+                        '2024-03-15T12:00:00.000Z'
+                    );
+                    done();
+                });
+        });
+
+        it('should handle approved=1 for moderators', done => {
+            const moderatorResponse: SaveArticleVersionResponseDto = {
+                ...mockSaveResponse,
+                approved: 1,
+            };
+            articleApiService.saveArticleVersion.mockReturnValue(
+                of(moderatorResponse)
+            );
+
+            spectator.service
+                .saveArticleVersion({
+                    versionId: 456,
+                    content: 'New content',
+                })
+                .subscribe(result => {
+                    expect(result.approved).toBe(1);
+                    done();
+                });
+        });
+
+        it('should work without optional info field', () => {
+            articleApiService.saveArticleVersion.mockReturnValue(
+                of(mockSaveResponse)
+            );
+
+            spectator.service
+                .saveArticleVersion({
+                    versionId: 456,
+                    content: 'New content',
+                })
+                .subscribe();
+
+            expect(articleApiService.saveArticleVersion).toHaveBeenCalledWith({
+                versionId: 456,
+                content: 'New content',
+            });
         });
     });
 });

--- a/apps/client/src/app/services/articles/article.service.ts
+++ b/apps/client/src/app/services/articles/article.service.ts
@@ -9,6 +9,9 @@ import {
     ArticleSearchResult,
     ArticleSearchParams,
     ArticleVersionDto,
+    SaveArticleVersionRequest,
+    SaveArticleVersionResult,
+    SaveArticleVersionResponseDto,
 } from '@drevo-web/shared';
 import { ArticleApiService } from './article-api.service';
 import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
@@ -75,6 +78,20 @@ export class ArticleService {
             .pipe(map(response => this.mapSearchResponse(response)));
     }
 
+    /**
+     * Save article version
+     *
+     * @param request - Save request with versionId, content, and optional info
+     * @returns Observable with mapped save result
+     */
+    saveArticleVersion(
+        request: SaveArticleVersionRequest
+    ): Observable<SaveArticleVersionResult> {
+        return this.articleApiService
+            .saveArticleVersion(request)
+            .pipe(map(response => this.mapSaveResponse(response)));
+    }
+
     private mapArticleVersion(response: ArticleVersionDto): ArticleVersion {
         return {
             articleId: response.articleId,
@@ -120,6 +137,19 @@ export class ArticleService {
         return {
             id: item.id,
             title: item.title,
+        };
+    }
+
+    private mapSaveResponse(
+        response: SaveArticleVersionResponseDto
+    ): SaveArticleVersionResult {
+        return {
+            articleId: response.articleId,
+            versionId: response.versionId,
+            title: response.title,
+            author: response.author,
+            date: new Date(response.date),
+            approved: response.approved,
         };
     }
 }

--- a/apps/client/src/app/services/articles/article.service.ts
+++ b/apps/client/src/app/services/articles/article.service.ts
@@ -1,6 +1,6 @@
+import { ArticleApiService } from './article-api.service';
+import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
 import { Injectable, inject } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import {
     ArticleVersion,
     ArticleSearchResponseDto,
@@ -13,8 +13,8 @@ import {
     SaveArticleVersionResult,
     SaveArticleVersionResponseDto,
 } from '@drevo-web/shared';
-import { ArticleApiService } from './article-api.service';
-import { DEFAULT_ARTICLE_SEARCH_PAGE_SIZE } from './article.constants';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 /**
  * Main service for article-related operations.

--- a/apps/client/src/app/services/auth/auth.service.spec.ts
+++ b/apps/client/src/app/services/auth/auth.service.spec.ts
@@ -1,17 +1,17 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideHttpClient } from '@angular/common/http';
 import {
     HttpTestingController,
     provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
 import { PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { of, throwError } from 'rxjs';
-import { AuthService } from './auth.service';
-import { CsrfService } from './csrf.service';
 import { LoggerService, StorageService } from '@drevo-web/core';
 import { mockLoggerProvider, MockLoggerService } from '@drevo-web/core/testing';
 import { AuthResponse, User } from '@drevo-web/shared';
+import { AuthService } from './auth.service';
+import { CsrfService } from './csrf.service';
 
 jest.mock('../../../environments/environment', () => ({
     environment: { apiUrl: 'http://test-api', production: false },

--- a/apps/client/src/app/services/auth/auth.service.ssr.spec.ts
+++ b/apps/client/src/app/services/auth/auth.service.ssr.spec.ts
@@ -1,13 +1,13 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideHttpClient } from '@angular/common/http';
 import {
     HttpTestingController,
     provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
 import { PLATFORM_ID } from '@angular/core';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { mockLoggerProvider } from '@drevo-web/core/testing';
 import { AuthService } from './auth.service';
 import { CsrfService } from './csrf.service';
-import { mockLoggerProvider } from '@drevo-web/core/testing';
 
 jest.mock('../../../environments/environment', () => ({
     environment: { apiUrl: 'http://test-api', production: false },

--- a/apps/client/src/app/services/auth/auth.service.ts
+++ b/apps/client/src/app/services/auth/auth.service.ts
@@ -1,11 +1,26 @@
-import { Injectable, inject, PLATFORM_ID } from '@angular/core';
+import { CsrfService } from './csrf.service';
+import { environment } from '../../../environments/environment';
 import { isPlatformBrowser } from '@angular/common';
 import {
     HttpClient,
     HttpContext,
     HttpErrorResponse,
 } from '@angular/common/http';
+import { Injectable, inject, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
+import {
+    LoggerService,
+    SKIP_ERROR_FOR_STATUSES,
+    StorageService,
+    WINDOW,
+} from '@drevo-web/core';
+import {
+    User,
+    AuthState,
+    AuthResponse,
+    LoginRequest,
+    isValidReturnUrl,
+} from '@drevo-web/shared';
 import {
     BehaviorSubject,
     Observable,
@@ -21,21 +36,7 @@ import {
     switchMap,
     take,
 } from 'rxjs/operators';
-import { environment } from '../../../environments/environment';
-import {
-    User,
-    AuthState,
-    AuthResponse,
-    LoginRequest,
-    isValidReturnUrl,
-} from '@drevo-web/shared';
-import { CsrfService } from './csrf.service';
-import {
-    LoggerService,
-    SKIP_ERROR_FOR_STATUSES,
-    StorageService,
-    WINDOW,
-} from '@drevo-web/core';
+
 
 @Injectable({
     providedIn: 'root',

--- a/apps/client/src/app/services/auth/csrf.service.spec.ts
+++ b/apps/client/src/app/services/auth/csrf.service.spec.ts
@@ -1,14 +1,14 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideHttpClient } from '@angular/common/http';
 import {
     HttpTestingController,
     provideHttpClientTesting,
 } from '@angular/common/http/testing';
-import { provideHttpClient } from '@angular/common/http';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { forkJoin } from 'rxjs';
-import { CsrfService } from './csrf.service';
-import { CsrfResponse } from '@drevo-web/shared';
 import { LoggerService } from '@drevo-web/core';
 import { mockLoggerProvider, MockLoggerService } from '@drevo-web/core/testing';
+import { CsrfResponse } from '@drevo-web/shared';
+import { CsrfService } from './csrf.service';
 
 jest.mock('../../../environments/environment', () => ({
     environment: { apiUrl: 'http://test-api' },

--- a/apps/client/src/app/services/auth/csrf.service.ts
+++ b/apps/client/src/app/services/auth/csrf.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, Injector, PLATFORM_ID, inject } from '@angular/core';
+import { environment } from '../../../environments/environment';
 import { isPlatformBrowser } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
+import { Injectable, Injector, PLATFORM_ID, inject } from '@angular/core';
+import { LoggerService } from '@drevo-web/core';
+import { CsrfResponse } from '@drevo-web/shared';
 import { Observable, of, throwError } from 'rxjs';
 import {
     map,
@@ -10,9 +13,6 @@ import {
     retry,
     shareReplay,
 } from 'rxjs/operators';
-import { environment } from '../../../environments/environment';
-import { CsrfResponse } from '@drevo-web/shared';
-import { LoggerService } from '@drevo-web/core';
 
 const CSRF_TIMEOUT_MS = 10000;
 const CSRF_RETRY_COUNT = 3;

--- a/apps/client/src/app/services/iframe/iframe.service.ts
+++ b/apps/client/src/app/services/iframe/iframe.service.ts
@@ -1,7 +1,7 @@
-import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import { BehaviorSubject, Observable, ReplaySubject, Subject } from 'rxjs';
+import { inject, Injectable, OnDestroy, PLATFORM_ID } from '@angular/core';
 import { InsertTagCommand } from '@drevo-web/shared';
+import { BehaviorSubject, Observable, ReplaySubject, Subject } from 'rxjs';
 
 const allowedOrigins = [
     'http://drevo-local.ru',

--- a/apps/client/src/app/services/links/links.service.spec.ts
+++ b/apps/client/src/app/services/links/links.service.spec.ts
@@ -1,7 +1,7 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
-import { LinksService } from './links.service';
-import { IframeService } from '../iframe/iframe.service';
 import { HttpClient } from '@angular/common/http';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { IframeService } from '../iframe/iframe.service';
+import { LinksService } from './links.service';
 
 describe('LinksStateService', () => {
     let spectator: SpectatorService<LinksService>;

--- a/apps/client/src/app/services/links/links.service.ts
+++ b/apps/client/src/app/services/links/links.service.ts
@@ -1,7 +1,7 @@
-import { inject, Injectable } from '@angular/core';
-import { debounceTime, filter, map, Observable, of, switchMap } from 'rxjs';
 import { IframeService } from '../iframe/iframe.service';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { debounceTime, filter, map, Observable, of, switchMap } from 'rxjs';
 
 interface RawResponse {
     [key: string]: { isExist: boolean };

--- a/apps/client/src/app/services/theme/theme.service.spec.ts
+++ b/apps/client/src/app/services/theme/theme.service.spec.ts
@@ -1,5 +1,5 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { PLATFORM_ID } from '@angular/core';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { ThemeService } from './theme.service';
 
 describe('ThemeService', () => {

--- a/apps/client/src/app/services/theme/theme.service.ts
+++ b/apps/client/src/app/services/theme/theme.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, signal, effect, PLATFORM_ID, inject } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { Injectable, signal, effect, PLATFORM_ID, inject } from '@angular/core';
 
 export type Theme = 'light' | 'dark';
 

--- a/apps/client/src/app/services/version/version.service.ts
+++ b/apps/client/src/app/services/version/version.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
 import { environment } from '../../../environments/environment';
+import { Injectable } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class VersionService {

--- a/apps/client/src/main.server.ts
+++ b/apps/client/src/main.server.ts
@@ -1,9 +1,9 @@
+import { AppComponent } from './app/app.component';
+import { config } from './app/app.config.server';
 import {
     bootstrapApplication,
     BootstrapContext,
 } from '@angular/platform-browser';
-import { AppComponent } from './app/app.component';
-import { config } from './app/app.config.server';
 
 // BootstrapContext carries per-request state for SSR (transfer state, providers, etc.)
 const bootstrap = (context: BootstrapContext) =>

--- a/apps/client/src/main.ts
+++ b/apps/client/src/main.ts
@@ -1,10 +1,10 @@
-import { bootstrapApplication } from '@angular/platform-browser';
-import { mergeApplicationConfig } from '@angular/core';
-import * as Sentry from '@sentry/angular';
+import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
 import { browserConfig } from './app/app.config.browser';
-import { AppComponent } from './app/app.component';
 import { environment } from './environments/environment';
+import { mergeApplicationConfig } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import * as Sentry from '@sentry/angular';
 
 // Initialize Sentry as early as possible for global error catching
 if (environment.sentryDsn && environment.production) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import nx from '@nx/eslint-plugin';
 import noNull from 'eslint-plugin-no-null';
+import importPlugin from 'eslint-plugin-import';
 
 export default [
     ...nx.configs['flat/base'],
@@ -10,7 +11,22 @@ export default [
     },
     {
         files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+        plugins: {
+            import: importPlugin,
+        },
         rules: {
+            'import/no-duplicates': 'error',
+            'import/order': [
+                'error',
+                {
+                    groups: [['builtin', 'external', 'internal', 'parent', 'sibling', 'index']],
+                    'newlines-between': 'never',
+                    alphabetize: {
+                        order: 'asc',
+                        caseInsensitive: true,
+                    },
+                },
+            ],
             '@nx/enforce-module-boundaries': [
                 'error',
                 {
@@ -47,6 +63,7 @@ export default [
         rules: {
             '@typescript-eslint/no-empty-function': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
+            'import/order': 'off',
         },
     },
     {

--- a/libs/core/src/lib/http/error-notification.interceptor.spec.ts
+++ b/libs/core/src/lib/http/error-notification.interceptor.spec.ts
@@ -9,14 +9,14 @@ import {
     HttpMethod,
     SpectatorHttp,
 } from '@ngneat/spectator/jest';
-import { ErrorNotificationInterceptor } from './error-notification.interceptor';
 import { NotificationService } from '../services/notification.service';
-import { HttpErrorMapperService } from './http-error-mapper.service';
+import { ErrorNotificationInterceptor } from './error-notification.interceptor';
 import {
     SKIP_ERROR_NOTIFICATION,
     CUSTOM_ERROR_MESSAGE,
     SKIP_ERROR_FOR_STATUSES,
 } from './http-context-tokens';
+import { HttpErrorMapperService } from './http-error-mapper.service';
 
 /**
  * Dummy service to make HTTP requests through the interceptor.

--- a/libs/core/src/lib/http/error-notification.interceptor.ts
+++ b/libs/core/src/lib/http/error-notification.interceptor.ts
@@ -1,4 +1,10 @@
-import { Injectable, inject } from '@angular/core';
+import {
+    SKIP_ERROR_NOTIFICATION,
+    CUSTOM_ERROR_MESSAGE,
+    SKIP_ERROR_FOR_STATUSES,
+} from './http-context-tokens';
+import { HttpErrorMapperService } from './http-error-mapper.service';
+import { NotificationService } from '../services/notification.service';
 import {
     HttpInterceptor,
     HttpRequest,
@@ -7,15 +13,9 @@ import {
     HttpErrorResponse,
     HTTP_INTERCEPTORS,
 } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
-import { NotificationService } from '../services/notification.service';
-import { HttpErrorMapperService } from './http-error-mapper.service';
-import {
-    SKIP_ERROR_NOTIFICATION,
-    CUSTOM_ERROR_MESSAGE,
-    SKIP_ERROR_FOR_STATUSES,
-} from './http-context-tokens';
 
 /**
  * HTTP interceptor that automatically shows toast notifications for HTTP errors.

--- a/libs/core/src/lib/http/http-error-mapper.service.spec.ts
+++ b/libs/core/src/lib/http/http-error-mapper.service.spec.ts
@@ -1,5 +1,5 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { HttpErrorResponse } from '@angular/common/http';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import {
     HttpErrorMapperService,
     MappedHttpError,

--- a/libs/core/src/lib/http/http-error-mapper.service.ts
+++ b/libs/core/src/lib/http/http-error-mapper.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 
 /**
  * Extracted error info for consistent handling

--- a/libs/core/src/lib/logging/log-database.ts
+++ b/libs/core/src/lib/logging/log-database.ts
@@ -1,5 +1,5 @@
-import Dexie, { Table } from 'dexie';
 import { LogEntry } from './log-provider.interface';
+import Dexie, { Table } from 'dexie';
 
 /**
  * IndexedDB table entry (LogEntry with required id)

--- a/libs/core/src/lib/logging/log-dispatcher.service.spec.ts
+++ b/libs/core/src/lib/logging/log-dispatcher.service.spec.ts
@@ -1,5 +1,5 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { PLATFORM_ID } from '@angular/core';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import {
     LogDispatcher,
     LOG_PRODUCTION_MODE,

--- a/libs/core/src/lib/logging/log-dispatcher.service.ts
+++ b/libs/core/src/lib/logging/log-dispatcher.service.ts
@@ -1,5 +1,3 @@
-import { inject, Injectable, InjectionToken, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
 import {
     LogEntry,
     LogLevel,
@@ -9,6 +7,8 @@ import {
 } from './log-provider.interface';
 import { sanitizeLogEntry } from './log-sanitizer';
 import { ConsoleLogProvider } from './providers/console-log.provider';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, InjectionToken, PLATFORM_ID } from '@angular/core';
 
 /**
  * Injection token for log providers

--- a/libs/core/src/lib/logging/log-export.service.spec.ts
+++ b/libs/core/src/lib/logging/log-export.service.spec.ts
@@ -1,8 +1,8 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { PLATFORM_ID } from '@angular/core';
-import { LogExportService } from './log-export.service';
-import { LogDispatcher } from './log-dispatcher.service';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { NotificationService } from '../services/notification.service';
+import { LogDispatcher } from './log-dispatcher.service';
+import { LogExportService } from './log-export.service';
 import { LogStorageProvider, LogEntry } from './log-provider.interface';
 
 describe('LogExportService', () => {

--- a/libs/core/src/lib/logging/log-export.service.ts
+++ b/libs/core/src/lib/logging/log-export.service.ts
@@ -1,8 +1,9 @@
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
 import { LogDispatcher } from './log-dispatcher.service';
 import { LogEntry } from './log-provider.interface';
 import { NotificationService } from '../services/notification.service';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+
 
 /**
  * Service for exporting logs as a downloadable CSV file

--- a/libs/core/src/lib/logging/log-export.service.ts
+++ b/libs/core/src/lib/logging/log-export.service.ts
@@ -4,7 +4,6 @@ import { NotificationService } from '../services/notification.service';
 import { isPlatformBrowser } from '@angular/common';
 import { inject, Injectable, PLATFORM_ID } from '@angular/core';
 
-
 /**
  * Service for exporting logs as a downloadable CSV file
  */

--- a/libs/core/src/lib/logging/logger.service.spec.ts
+++ b/libs/core/src/lib/logging/logger.service.spec.ts
@@ -1,6 +1,6 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
-import { LoggerService } from './logger.service';
 import { LogDispatcher } from './log-dispatcher.service';
+import { LoggerService } from './logger.service';
 
 describe('LoggerService', () => {
     let spectator: SpectatorService<LoggerService>;

--- a/libs/core/src/lib/logging/logger.service.ts
+++ b/libs/core/src/lib/logging/logger.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, inject } from '@angular/core';
 import { LogDispatcher } from './log-dispatcher.service';
 import { LogLevel } from './log-provider.interface';
+import { Injectable, inject } from '@angular/core';
 
 /**
  * Logger interface matching console API

--- a/libs/core/src/lib/logging/providers/console-log.provider.spec.ts
+++ b/libs/core/src/lib/logging/providers/console-log.provider.spec.ts
@@ -1,5 +1,5 @@
-import { ConsoleLogProvider } from './console-log.provider';
 import { LogEntry } from '../log-provider.interface';
+import { ConsoleLogProvider } from './console-log.provider';
 
 describe('ConsoleLogProvider', () => {
     let provider: ConsoleLogProvider;

--- a/libs/core/src/lib/logging/providers/indexed-db-log.provider.spec.ts
+++ b/libs/core/src/lib/logging/providers/indexed-db-log.provider.spec.ts
@@ -1,5 +1,5 @@
-import { IndexedDBLogProvider } from './indexed-db-log.provider';
 import { LogEntry } from '../log-provider.interface';
+import { IndexedDBLogProvider } from './indexed-db-log.provider';
 
 /**
  * Tests for IndexedDBLogProvider

--- a/libs/core/src/lib/logging/providers/indexed-db-log.provider.ts
+++ b/libs/core/src/lib/logging/providers/indexed-db-log.provider.ts
@@ -1,9 +1,9 @@
+import { LogDatabase } from '../log-database';
 import {
     LogEntry,
     LogStorageProvider,
     GetLogsOptions,
 } from '../log-provider.interface';
-import { LogDatabase } from '../log-database';
 import { assertIsDefined } from '@drevo-web/shared';
 
 /** Default max storage size in bytes (10MB) */

--- a/libs/core/src/lib/logging/providers/sentry-log.provider.spec.ts
+++ b/libs/core/src/lib/logging/providers/sentry-log.provider.spec.ts
@@ -1,5 +1,5 @@
-import { SentryLogProvider } from './sentry-log.provider';
 import { LogEntry, LogLevel } from '../log-provider.interface';
+import { SentryLogProvider } from './sentry-log.provider';
 
 // Mock Sentry module
 jest.mock('@sentry/angular', () => ({

--- a/libs/core/src/lib/logging/providers/sentry-log.provider.ts
+++ b/libs/core/src/lib/logging/providers/sentry-log.provider.ts
@@ -1,5 +1,5 @@
-import * as Sentry from '@sentry/angular';
 import { LogEntry, LogProvider, LogLevel } from '../log-provider.interface';
+import * as Sentry from '@sentry/angular';
 
 /**
  * Configuration options for Sentry log provider

--- a/libs/core/src/lib/services/notification.service.spec.ts
+++ b/libs/core/src/lib/services/notification.service.spec.ts
@@ -1,9 +1,9 @@
+import { MatSnackBar } from '@angular/material/snack-bar';
 import {
     createServiceFactory,
     SpectatorService,
     SpyObject,
 } from '@ngneat/spectator/jest';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { NotificationService } from './notification.service';
 
 describe('NotificationService', () => {

--- a/libs/core/src/lib/services/sidebar.service.spec.ts
+++ b/libs/core/src/lib/services/sidebar.service.spec.ts
@@ -1,6 +1,6 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
-import { SidebarService } from './sidebar.service';
 import { SidebarAction } from '@drevo-web/shared';
+import { SidebarService } from './sidebar.service';
 
 describe('SidebarService', () => {
     let spectator: SpectatorService<SidebarService>;

--- a/libs/core/src/lib/services/storage.service.spec.ts
+++ b/libs/core/src/lib/services/storage.service.spec.ts
@@ -1,8 +1,8 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { PLATFORM_ID } from '@angular/core';
-import { StorageService } from './storage.service';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { LoggerService } from '../logging/logger.service';
 import { WINDOW } from '../tokens/window.token';
+import { StorageService } from './storage.service';
 
 describe('StorageService', () => {
     let spectator: SpectatorService<StorageService>;

--- a/libs/core/src/lib/services/storage.service.ts
+++ b/libs/core/src/lib/services/storage.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, inject, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
 import { LoggerService } from '../logging/logger.service';
 import { WINDOW } from '../tokens/window.token';
+import { isPlatformBrowser } from '@angular/common';
+import { Injectable, inject, PLATFORM_ID } from '@angular/core';
 
 /**
  * SSR-safe localStorage wrapper with JSON serialization support.

--- a/libs/core/src/lib/tokens/window.token.ts
+++ b/libs/core/src/lib/tokens/window.token.ts
@@ -1,5 +1,5 @@
-import { InjectionToken, inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
+import { InjectionToken, inject, PLATFORM_ID } from '@angular/core';
 
 /**
  * Injection token for the browser's Window object.

--- a/libs/editor/src/lib/components/editor/editor.component.ts
+++ b/libs/editor/src/lib/components/editor/editor.component.ts
@@ -1,3 +1,6 @@
+import { linksUpdatedEffect } from '../../constants/editor-effects';
+import { EditorFactoryService } from '../../services/editor-factory/editor-factory.service';
+import { WikiHighlighterService } from '../../services/wiki-highlighter/wiki-highlighter.service';
 import {
     AfterViewInit,
     Component,
@@ -10,14 +13,10 @@ import {
     Output,
     ViewChild,
 } from '@angular/core';
-
-import { EditorView } from '@codemirror/view';
-import { WikiHighlighterService } from '../../services/wiki-highlighter/wiki-highlighter.service';
-import { linksUpdatedEffect } from '../../constants/editor-effects';
-import { BehaviorSubject, filter } from 'rxjs';
-import { InsertTagCommand } from '@drevo-web/shared';
-import { EditorFactoryService } from '../../services/editor-factory/editor-factory.service';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { EditorView } from '@codemirror/view';
+import { InsertTagCommand } from '@drevo-web/shared';
+import { BehaviorSubject, filter } from 'rxjs';
 
 @Component({
     selector: 'lib-editor',

--- a/libs/editor/src/lib/helpers/list-commands.spec.ts
+++ b/libs/editor/src/lib/helpers/list-commands.spec.ts
@@ -1,7 +1,7 @@
 // list-commands.spec.ts
 import { EditorState } from '@codemirror/state';
-import { continueLists } from './list-commands';
 import { EditorView, keymap } from '@codemirror/view';
+import { continueLists } from './list-commands';
 
 type Case = { title: string; prev: string; next: string };
 

--- a/libs/editor/src/lib/services/editor-factory/editor-factory.service.ts
+++ b/libs/editor/src/lib/services/editor-factory/editor-factory.service.ts
@@ -1,8 +1,23 @@
-import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { russianPhrases } from '../../constants/editor-phrases';
+import {
+    continueLists,
+    decreaseListIndent,
+    increaseListIndent,
+} from '../../helpers/list-commands';
+import { quoteKeymap } from '../../helpers/quote-commands';
 import { WikiHighlighterService } from '../wiki-highlighter/wiki-highlighter.service';
 import { isPlatformServer } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { closeBrackets } from '@codemirror/autocomplete';
+import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
+import {
+    bracketMatching,
+    defaultHighlightStyle,
+    indentOnInput,
+    syntaxHighlighting,
+} from '@codemirror/language';
+import { openSearchPanel, search, searchKeymap } from '@codemirror/search';
 import { EditorState } from '@codemirror/state';
-import { russianPhrases } from '../../constants/editor-phrases';
 import {
     drawSelection,
     dropCursor,
@@ -11,21 +26,6 @@ import {
     keymap,
     ViewUpdate,
 } from '@codemirror/view';
-import {
-    bracketMatching,
-    defaultHighlightStyle,
-    indentOnInput,
-    syntaxHighlighting,
-} from '@codemirror/language';
-import { closeBrackets } from '@codemirror/autocomplete';
-import { openSearchPanel, search, searchKeymap } from '@codemirror/search';
-import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
-import {
-    continueLists,
-    decreaseListIndent,
-    increaseListIndent,
-} from '../../helpers/list-commands';
-import { quoteKeymap } from '../../helpers/quote-commands';
 
 @Injectable()
 export class EditorFactoryService {

--- a/libs/editor/src/lib/services/wiki-highlighter/wiki-highlighter.service.spec.ts
+++ b/libs/editor/src/lib/services/wiki-highlighter/wiki-highlighter.service.spec.ts
@@ -1,8 +1,9 @@
-import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { EditorState } from '@codemirror/state';
 import { EditorView } from '@codemirror/view';
-import { WikiHighlighterService } from './wiki-highlighter.service';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { linksUpdatedEffect } from '../../constants/editor-effects';
+import { WikiHighlighterService } from './wiki-highlighter.service';
+
 
 const pendingSelector = '.cm-link-pending';
 const existsSelector = '.cm-link-exists';

--- a/libs/editor/src/lib/services/wiki-highlighter/wiki-highlighter.service.ts
+++ b/libs/editor/src/lib/services/wiki-highlighter/wiki-highlighter.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@angular/core';
-import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
-import { RangeSetBuilder, StateField } from '@codemirror/state';
 import { linksUpdatedEffect } from '../../constants/editor-effects';
+import { Injectable } from '@angular/core';
+import { RangeSetBuilder, StateField } from '@codemirror/state';
+import { Decoration, DecorationSet, EditorView } from '@codemirror/view';
 import { Subject } from 'rxjs';
 
 interface Match {

--- a/libs/shared/src/lib/models/article.ts
+++ b/libs/shared/src/lib/models/article.ts
@@ -14,3 +14,24 @@ export interface ArticleVersion extends Article {
     readonly info: string;
     readonly comment: string;
 }
+
+/**
+ * Request for saving article version
+ */
+export interface SaveArticleVersionRequest {
+    readonly versionId: number;
+    readonly content: string;
+    readonly info?: string;
+}
+
+/**
+ * Result of saving article version
+ */
+export interface SaveArticleVersionResult {
+    readonly articleId: number;
+    readonly versionId: number;
+    readonly title: string;
+    readonly author: string;
+    readonly date: Date;
+    readonly approved: number;
+}

--- a/libs/shared/src/lib/models/dto/article.dto.ts
+++ b/libs/shared/src/lib/models/dto/article.dto.ts
@@ -36,3 +36,25 @@ export interface ArticleVersionDto extends ArticlePageDto {
     readonly info: string;
     readonly comment: string;
 }
+
+/**
+ * Request body for saving article version
+ */
+export interface SaveArticleVersionRequestDto {
+    readonly versionId: number;
+    readonly content: string;
+    readonly info?: string;
+}
+
+/**
+ * Response from saving article version
+ */
+export interface SaveArticleVersionResponseDto {
+    readonly articleId: number;
+    readonly versionId: number;
+    readonly title: string;
+    readonly content: string;
+    readonly author: string;
+    readonly date: string;
+    readonly approved: number;
+}

--- a/libs/ui/src/lib/components/action-button/action-button.component.spec.ts
+++ b/libs/ui/src/lib/components/action-button/action-button.component.spec.ts
@@ -1,5 +1,5 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { RouterTestingModule } from '@angular/router/testing';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { ActionButtonComponent } from './action-button.component';
 
 describe('ActionButtonComponent', () => {

--- a/libs/ui/src/lib/components/action-button/action-button.component.ts
+++ b/libs/ui/src/lib/components/action-button/action-button.component.ts
@@ -4,10 +4,10 @@ import {
     input,
     output,
 } from '@angular/core';
-import { RouterLink } from '@angular/router';
 import { MatFabButton, MatMiniFabButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
+import { RouterLink } from '@angular/router';
 import { SidebarActionPriority } from '@drevo-web/shared';
 
 export type ActionButtonVariant = 'default' | 'main' | 'menu' | 'speed-dial';

--- a/libs/ui/src/lib/components/button/button.component.spec.ts
+++ b/libs/ui/src/lib/components/button/button.component.spec.ts
@@ -1,7 +1,7 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { ButtonComponent } from './button.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { ButtonComponent } from './button.component';
 
 describe('ButtonComponent', () => {
     let spectator: Spectator<ButtonComponent>;

--- a/libs/ui/src/lib/components/button/button.component.ts
+++ b/libs/ui/src/lib/components/button/button.component.ts
@@ -1,13 +1,13 @@
+import { NgTemplateOutlet } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
     input,
     output,
 } from '@angular/core';
-import { NgTemplateOutlet } from '@angular/common';
-import { RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { RouterLink } from '@angular/router';
 
 export type ButtonVariant = 'primary' | 'secondary' | 'text';
 export type ButtonType = 'button' | 'submit' | 'reset';

--- a/libs/ui/src/lib/components/checkbox/checkbox.component.spec.ts
+++ b/libs/ui/src/lib/components/checkbox/checkbox.component.spec.ts
@@ -1,6 +1,6 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { CheckboxComponent } from './checkbox.component';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('CheckboxComponent', () => {
     let spectator: Spectator<CheckboxComponent>;

--- a/libs/ui/src/lib/components/icon-button/icon-button.component.spec.ts
+++ b/libs/ui/src/lib/components/icon-button/icon-button.component.spec.ts
@@ -1,6 +1,6 @@
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatTooltip } from '@angular/material/tooltip';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { IconButtonComponent } from './icon-button.component';
 
 describe('IconButtonComponent', () => {

--- a/libs/ui/src/lib/components/icon/icon.component.spec.ts
+++ b/libs/ui/src/lib/components/icon/icon.component.spec.ts
@@ -1,6 +1,6 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { IconComponent } from './icon.component';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('IconComponent', () => {
     let spectator: Spectator<IconComponent>;

--- a/libs/ui/src/lib/components/right-sidebar/right-sidebar.component.ts
+++ b/libs/ui/src/lib/components/right-sidebar/right-sidebar.component.ts
@@ -1,7 +1,7 @@
+import { ActionButtonComponent } from '../action-button/action-button.component';
 import { Component, ChangeDetectionStrategy, inject, signal } from '@angular/core';
 import { SidebarService } from '@drevo-web/core';
 import { SidebarAction } from '@drevo-web/shared';
-import { ActionButtonComponent } from '../action-button/action-button.component';
 
 @Component({
     selector: 'ui-right-sidebar',

--- a/libs/ui/src/lib/components/spinner/spinner.component.spec.ts
+++ b/libs/ui/src/lib/components/spinner/spinner.component.spec.ts
@@ -1,6 +1,6 @@
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { SpinnerComponent } from './spinner.component';
-import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 describe('SpinnerComponent', () => {
     let spectator: Spectator<SpinnerComponent>;

--- a/libs/ui/src/lib/components/text-input/text-input.component.spec.ts
+++ b/libs/ui/src/lib/components/text-input/text-input.component.spec.ts
@@ -1,6 +1,6 @@
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { TextInputComponent } from './text-input.component';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('TextInputComponent', () => {
     let spectator: Spectator<TextInputComponent>;

--- a/libs/ui/src/lib/components/virtual-scroller/virtual-scroller.component.spec.ts
+++ b/libs/ui/src/lib/components/virtual-scroller/virtual-scroller.component.spec.ts
@@ -1,8 +1,7 @@
-import { SpectatorHost, createHostFactory } from '@ngneat/spectator/jest';
 import { ScrollingModule } from '@angular/cdk/scrolling';
 import { fakeAsync, tick } from '@angular/core/testing';
+import { SpectatorHost, createHostFactory } from '@ngneat/spectator/jest';
 import { Subject } from 'rxjs';
-
 import { VirtualScrollerComponent } from './virtual-scroller.component';
 
 interface TestItem {

--- a/libs/ui/src/lib/components/virtual-scroller/virtual-scroller.component.ts
+++ b/libs/ui/src/lib/components/virtual-scroller/virtual-scroller.component.ts
@@ -1,3 +1,11 @@
+import { VirtualScrollerItemDirective } from './virtual-scroller-item.directive';
+import { SpinnerComponent } from '../spinner/spinner.component';
+import {
+    CdkVirtualForOf,
+    CdkVirtualScrollViewport,
+} from '@angular/cdk/scrolling';
+import { CdkAutoSizeVirtualScroll } from '@angular/cdk-experimental/scrolling';
+import { NgTemplateOutlet } from '@angular/common';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -10,16 +18,8 @@ import {
     output,
     viewChild,
 } from '@angular/core';
-import { NgTemplateOutlet } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-    CdkVirtualForOf,
-    CdkVirtualScrollViewport,
-} from '@angular/cdk/scrolling';
-import { CdkAutoSizeVirtualScroll } from '@angular/cdk-experimental/scrolling';
 import { filter, throttleTime } from 'rxjs';
-import { SpinnerComponent } from '../spinner/spinner.component';
-import { VirtualScrollerItemDirective } from './virtual-scroller-item.directive';
 
 export { VirtualScrollerItemDirective } from './virtual-scroller-item.directive';
 

--- a/libs/ui/src/lib/directives/sidebar-action.directive.spec.ts
+++ b/libs/ui/src/lib/directives/sidebar-action.directive.spec.ts
@@ -3,9 +3,9 @@ import {
     SpectatorDirective,
     SpyObject,
 } from '@ngneat/spectator/jest';
-import { SidebarActionDirective } from './sidebar-action.directive';
 import { SidebarService } from '@drevo-web/core';
 import { SidebarAction } from '@drevo-web/shared';
+import { SidebarActionDirective } from './sidebar-action.directive';
 
 describe('SidebarActionDirective', () => {
     let spectator: SpectatorDirective<SidebarActionDirective>;

--- a/libs/ui/src/lib/directives/sidebar-action.directive.spec.ts
+++ b/libs/ui/src/lib/directives/sidebar-action.directive.spec.ts
@@ -196,4 +196,53 @@ describe('SidebarActionDirective', () => {
             expect(action.disabled).toBe(true);
         });
     });
+
+    describe('dynamic disabled changes', () => {
+        beforeEach(() => {
+            spectator = createDirective(
+                `<button sidebarAction icon="edit" [disabled]="isDisabled">Edit</button>`,
+                { hostProps: { isDisabled: false } }
+            );
+            sidebarService = spectator.inject(SidebarService);
+        });
+
+        it('should register action with initial disabled state', () => {
+            const action = sidebarService.registerAction.mock.calls[0][0];
+
+            expect(action.disabled).toBe(false);
+        });
+
+        it('should re-register action when disabled changes', () => {
+            const callsBefore = sidebarService.registerAction.mock.calls.length;
+
+            spectator.setHostInput({ isDisabled: true });
+
+            expect(sidebarService.registerAction.mock.calls.length).toBe(
+                callsBefore + 1
+            );
+        });
+
+        it('should register action with updated disabled state', () => {
+            spectator.setHostInput({ isDisabled: true });
+
+            const lastCall =
+                sidebarService.registerAction.mock.calls[
+                    sidebarService.registerAction.mock.calls.length - 1
+                ][0];
+
+            expect(lastCall.disabled).toBe(true);
+        });
+
+        it('should preserve action id when re-registering', () => {
+            const initialAction =
+                sidebarService.registerAction.mock.calls[0][0];
+
+            spectator.setHostInput({ isDisabled: true });
+
+            const calls = sidebarService.registerAction.mock.calls;
+            const updatedAction = calls[calls.length - 1][0];
+
+            expect(updatedAction.id).toBe(initialAction.id);
+        });
+    });
 });

--- a/libs/ui/src/lib/directives/sidebar-action.directive.ts
+++ b/libs/ui/src/lib/directives/sidebar-action.directive.ts
@@ -1,10 +1,11 @@
 import {
     Directive,
-    Input,
     OnInit,
     OnDestroy,
     inject,
     ElementRef,
+    input,
+    effect,
 } from '@angular/core';
 import { SidebarService } from '@drevo-web/core';
 import { SidebarAction, SidebarActionPriority } from '@drevo-web/shared';
@@ -24,29 +25,45 @@ export class SidebarActionDirective implements OnInit, OnDestroy {
     private readonly elementRef = inject(ElementRef);
     private readonly actionId = `sidebar-action-${nextId++}`;
 
-    @Input({ required: true }) icon!: string;
-    @Input() priority: SidebarActionPriority = 'secondary';
-    @Input() href?: string;
-    @Input() disabled?: boolean;
+    readonly icon = input.required<string>();
+    readonly priority = input<SidebarActionPriority>('secondary');
+    readonly href = input<string>();
+    readonly disabled = input<boolean>();
+
+    private label = '';
+    private initialized = false;
+
+    constructor() {
+        effect(() => {
+            if (this.initialized) {
+                this.registerAction(this.disabled());
+            }
+        });
+    }
 
     ngOnInit(): void {
-        const label = this.elementRef.nativeElement.textContent?.trim() || '';
-
-        const action: SidebarAction = {
-            id: this.actionId,
-            icon: this.icon,
-            label,
-            priority: this.priority,
-            href: this.href,
-            disabled: this.disabled,
-            action: this.href ? undefined : () => this.triggerClick(),
-        };
-
-        this.sidebarService.registerAction(action);
+        this.label = this.elementRef.nativeElement.textContent?.trim() || '';
+        this.registerAction(this.disabled());
+        this.initialized = true;
     }
 
     ngOnDestroy(): void {
         this.sidebarService.unregisterAction(this.actionId);
+    }
+
+    private registerAction(disabled: boolean | undefined): void {
+        const href = this.href();
+        const action: SidebarAction = {
+            id: this.actionId,
+            icon: this.icon(),
+            label: this.label,
+            priority: this.priority(),
+            href,
+            disabled,
+            action: href ? undefined : () => this.triggerClick(),
+        };
+
+        this.sidebarService.registerAction(action);
     }
 
     private triggerClick(): void {

--- a/libs/ui/src/lib/modal/components/modal-container.component.spec.ts
+++ b/libs/ui/src/lib/modal/components/modal-container.component.spec.ts
@@ -1,7 +1,7 @@
-import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { Component, Type, inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
+import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { LoggerService } from '@drevo-web/core';
 import { MockLoggerService, mockLoggerProvider } from '@drevo-web/core/testing';
 import { MODAL_DATA } from '../models/modal.tokens';
@@ -49,7 +49,7 @@ describe('ModalContainerComponent', () => {
     };
 
     it('should show spinner while component is loading', async () => {
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
+         
         let resolveLoader: (
             component: Type<TestModalComponent>
         ) => void = () => {};

--- a/libs/ui/src/lib/modal/components/modal-container.component.ts
+++ b/libs/ui/src/lib/modal/components/modal-container.component.ts
@@ -1,3 +1,6 @@
+import { SpinnerComponent } from '../../components/spinner/spinner.component';
+import { MODAL_DATA } from '../models/modal.tokens';
+import { LazyComponentLoader, ModalData } from '../models/modal.types';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -9,9 +12,6 @@ import {
     viewChild,
 } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { SpinnerComponent } from '../../components/spinner/spinner.component';
-import { MODAL_DATA } from '../models/modal.tokens';
-import { LazyComponentLoader, ModalData } from '../models/modal.types';
 import { LoggerService } from '@drevo-web/core';
 
 interface LazyModalData<TData = unknown> {

--- a/libs/ui/src/lib/modal/models/modal.tokens.ts
+++ b/libs/ui/src/lib/modal/models/modal.tokens.ts
@@ -1,4 +1,4 @@
-import { InjectionToken } from '@angular/core';
 import { ModalData } from './modal.types';
+import { InjectionToken } from '@angular/core';
 
 export const MODAL_DATA = new InjectionToken<ModalData>('MODAL_DATA');

--- a/libs/ui/src/lib/modal/services/modal.service.spec.ts
+++ b/libs/ui/src/lib/modal/services/modal.service.spec.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { Subject } from 'rxjs';
-
 import { ModalContainerComponent } from '../components/modal-container.component';
 import { ModalConfig } from '../models/modal.types';
 import { ModalService } from './modal.service';

--- a/libs/ui/src/lib/modal/services/modal.service.ts
+++ b/libs/ui/src/lib/modal/services/modal.service.ts
@@ -1,13 +1,12 @@
-import { Injectable, inject } from '@angular/core';
-import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
-import { Observable } from 'rxjs';
-
 import { ModalContainerComponent } from '../components/modal-container.component';
 import {
     LazyComponentLoader,
     ModalConfig,
     ModalRef,
 } from '../models/modal.types';
+import { Injectable, inject } from '@angular/core';
+import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
+import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class ModalService {

--- a/libs/ui/src/lib/pipes/highlight/highlight.pipe.spec.ts
+++ b/libs/ui/src/lib/pipes/highlight/highlight.pipe.spec.ts
@@ -1,5 +1,4 @@
 import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
-
 import { HighlightPipe } from './highlight.pipe';
 
 describe('HighlightPipe', () => {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "angular-eslint": "21.1.0",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "10.1.8",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-no-null": "^1.0.2",
         "eslint-plugin-playwright": "^1.6.2",
         "jest": "^30.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4891,6 +4891,11 @@
     error-stack-parser "^2.1.4"
     html-entities "^2.6.0"
 
+"@rtsao/scc@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
+  integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
+
 "@schematics/angular@21.0.6":
   version "21.0.6"
   resolved "https://registry.yarnpkg.com/@schematics/angular/-/angular-21.0.6.tgz#78fd58a6e91337e17a5530b0caa816a17605ce86"
@@ -5461,6 +5466,11 @@
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/mime@^1":
   version "1.3.5"
@@ -6287,15 +6297,88 @@ aria-query@5.3.2:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
+array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
+  integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
+  dependencies:
+    call-bound "^1.0.3"
+    is-array-buffer "^3.0.5"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
 
+array-includes@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.9.tgz#1f0ccaa08e90cdbc3eb433210f903ad0f17c3f3a"
+  integrity sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.24.0"
+    es-object-atoms "^1.1.1"
+    get-intrinsic "^1.3.0"
+    is-string "^1.1.1"
+    math-intrinsics "^1.1.0"
+
 array-union@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
   integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
+
+array.prototype.findlastindex@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz#cfa1065c81dcb64e34557c9b81d012f6a421c564"
+  integrity sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.9"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-shim-unscopables "^1.1.0"
+
+array.prototype.flat@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz#534aaf9e6e8dd79fb6b9a9917f839ef1ec63afe5"
+  integrity sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-shim-unscopables "^1.0.2"
+
+array.prototype.flatmap@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz#712cc792ae70370ae40586264629e33aab5dd38b"
+  integrity sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-shim-unscopables "^1.0.2"
+
+arraybuffer.prototype.slice@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz#9d760d84dbdd06d0cbf92c8849615a1a7ab3183c"
+  integrity sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==
+  dependencies:
+    array-buffer-byte-length "^1.0.1"
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    is-array-buffer "^3.0.4"
+
+async-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
+  integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
 
 async@^3.2.3, async@^3.2.6:
   version "3.2.6"
@@ -6323,6 +6406,13 @@ autoprefixer@10.4.21, autoprefixer@^10.4.9:
     normalize-range "^0.1.2"
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
+
+available-typed-arrays@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
+  integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
+  dependencies:
+    possible-typed-array-names "^1.0.0"
 
 axios@^1.12.0:
   version "1.13.2"
@@ -6701,7 +6791,7 @@ cacache@^20.0.0, cacache@^20.0.1:
     ssri "^13.0.0"
     unique-filename "^5.0.0"
 
-call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
@@ -6709,7 +6799,17 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bound@^1.0.2:
+call-bind@^1.0.7, call-bind@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
+  integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
+  dependencies:
+    call-bind-apply-helpers "^1.0.0"
+    es-define-property "^1.0.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.2"
+
+call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
   integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
@@ -7353,6 +7453,33 @@ data-urls@^5.0.0:
     whatwg-mimetype "^4.0.0"
     whatwg-url "^14.0.0"
 
+data-view-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz#211a03ba95ecaf7798a8c7198d79536211f88570"
+  integrity sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.2"
+
+data-view-byte-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz#9e80f7ca52453ce3e93d25a35318767ea7704735"
+  integrity sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.2"
+
+data-view-byte-offset@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz#068307f9b71ab76dbbe10291389e020856606191"
+  integrity sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.1"
+
 date-format@^4.0.14:
   version "4.0.14"
   resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
@@ -7371,6 +7498,13 @@ debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, d
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
     ms "^2.1.3"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 debug@^4.3.5, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
@@ -7424,6 +7558,15 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-data-property@^1.0.1, define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
 define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
@@ -7433,6 +7576,15 @@ define-lazy-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
+
+define-properties@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
+  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
+  dependencies:
+    define-data-property "^1.0.1"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -7521,6 +7673,13 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
@@ -7573,7 +7732,7 @@ dotenv@~16.4.5:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
-dunder-proto@^1.0.1:
+dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
   integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
@@ -7727,7 +7886,67 @@ error-stack-parser@^2.1.4:
   dependencies:
     stackframe "^1.3.4"
 
-es-define-property@^1.0.1:
+es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
+  version "1.24.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.1.tgz#f0c131ed5ea1bb2411134a8dd94def09c46c7899"
+  integrity sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==
+  dependencies:
+    array-buffer-byte-length "^1.0.2"
+    arraybuffer.prototype.slice "^1.0.4"
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    data-view-buffer "^1.0.2"
+    data-view-byte-length "^1.0.2"
+    data-view-byte-offset "^1.0.1"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-set-tostringtag "^2.1.0"
+    es-to-primitive "^1.3.0"
+    function.prototype.name "^1.1.8"
+    get-intrinsic "^1.3.0"
+    get-proto "^1.0.1"
+    get-symbol-description "^1.1.0"
+    globalthis "^1.0.4"
+    gopd "^1.2.0"
+    has-property-descriptors "^1.0.2"
+    has-proto "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    internal-slot "^1.1.0"
+    is-array-buffer "^3.0.5"
+    is-callable "^1.2.7"
+    is-data-view "^1.0.2"
+    is-negative-zero "^2.0.3"
+    is-regex "^1.2.1"
+    is-set "^2.0.3"
+    is-shared-array-buffer "^1.0.4"
+    is-string "^1.1.1"
+    is-typed-array "^1.1.15"
+    is-weakref "^1.1.1"
+    math-intrinsics "^1.1.0"
+    object-inspect "^1.13.4"
+    object-keys "^1.1.1"
+    object.assign "^4.1.7"
+    own-keys "^1.0.1"
+    regexp.prototype.flags "^1.5.4"
+    safe-array-concat "^1.1.3"
+    safe-push-apply "^1.0.0"
+    safe-regex-test "^1.1.0"
+    set-proto "^1.0.0"
+    stop-iteration-iterator "^1.1.0"
+    string.prototype.trim "^1.2.10"
+    string.prototype.trimend "^1.0.9"
+    string.prototype.trimstart "^1.0.8"
+    typed-array-buffer "^1.0.3"
+    typed-array-byte-length "^1.0.3"
+    typed-array-byte-offset "^1.0.4"
+    typed-array-length "^1.0.7"
+    unbox-primitive "^1.1.0"
+    which-typed-array "^1.1.19"
+
+es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
@@ -7763,6 +7982,22 @@ es-set-tostringtag@^2.1.0:
     get-intrinsic "^1.2.6"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
+
+es-shim-unscopables@^1.0.2, es-shim-unscopables@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz#438df35520dac5d105f3943d927549ea3b00f4b5"
+  integrity sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==
+  dependencies:
+    hasown "^2.0.2"
+
+es-to-primitive@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.0.tgz#96c89c82cc49fd8794a24835ba3e1ff87f214e18"
+  integrity sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==
+  dependencies:
+    is-callable "^1.2.7"
+    is-date-object "^1.0.5"
+    is-symbol "^1.0.4"
 
 esbuild-wasm@0.26.0:
   version "0.26.0"
@@ -7898,6 +8133,47 @@ eslint-config-prettier@10.1.8:
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
+
+eslint-import-resolver-node@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz#d4eaac52b8a2e7c3cd1903eb00f7e053356118ac"
+  integrity sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==
+  dependencies:
+    debug "^3.2.7"
+    is-core-module "^2.13.0"
+    resolve "^1.22.4"
+
+eslint-module-utils@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz#f76d3220bfb83c057651359295ab5854eaad75ff"
+  integrity sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==
+  dependencies:
+    debug "^3.2.7"
+
+eslint-plugin-import@^2.32.0:
+  version "2.32.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz#602b55faa6e4caeaa5e970c198b5c00a37708980"
+  integrity sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==
+  dependencies:
+    "@rtsao/scc" "^1.1.0"
+    array-includes "^3.1.9"
+    array.prototype.findlastindex "^1.2.6"
+    array.prototype.flat "^1.3.3"
+    array.prototype.flatmap "^1.3.3"
+    debug "^3.2.7"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.9"
+    eslint-module-utils "^2.12.1"
+    hasown "^2.0.2"
+    is-core-module "^2.16.1"
+    is-glob "^4.0.3"
+    minimatch "^3.1.2"
+    object.fromentries "^2.0.8"
+    object.groupby "^1.0.3"
+    object.values "^1.2.1"
+    semver "^6.3.1"
+    string.prototype.trimend "^1.0.9"
+    tsconfig-paths "^3.15.0"
 
 eslint-plugin-no-null@^1.0.2:
   version "1.0.2"
@@ -8398,6 +8674,13 @@ follow-redirects@^1.0.0, follow-redirects@^1.15.6:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
+for-each@^0.3.3, for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
+  dependencies:
+    is-callable "^1.2.7"
+
 foreground-child@^3.1.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
@@ -8527,6 +8810,28 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.8.tgz#e68e1df7b259a5c949eeef95cdbde53edffabb78"
+  integrity sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    functions-have-names "^1.2.3"
+    hasown "^2.0.2"
+    is-callable "^1.2.7"
+
+functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+generator-function@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
+  integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -8547,7 +8852,7 @@ get-east-asian-width@^1.3.0:
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz#9bc4caa131702b4b61729cb7e42735bc550c9ee6"
   integrity sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -8580,6 +8885,15 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-symbol-description@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz#7bdd54e0befe8ffc9f3b4e203220d9f1e881b6ee"
+  integrity sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -8680,6 +8994,14 @@ globals@^15.9.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz#7c4761299d41c32b075715a4ce1ede7897ff72a8"
   integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
 
+globalthis@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"
+  integrity sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==
+  dependencies:
+    define-properties "^1.2.1"
+    gopd "^1.0.1"
+
 globby@^12.0.2:
   version "12.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-12.2.0.tgz#2ab8046b4fba4ff6eede835b29f678f90e3d3c22"
@@ -8692,7 +9014,7 @@ globby@^12.0.2:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
-gopd@^1.2.0:
+gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
@@ -8724,10 +9046,29 @@ harmony-reflect@^1.4.6:
   resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
   integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
 
+has-bigints@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
+  integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
+
+has-proto@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.2.0.tgz#5de5a6eabd95fdffd9818b43055e8065e39fe9d5"
+  integrity sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==
+  dependencies:
+    dunder-proto "^1.0.0"
 
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
@@ -9073,6 +9414,15 @@ ini@^6.0.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-6.0.0.tgz#efc7642b276f6a37d22fdf56ef50889d7146bf30"
   integrity sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==
 
+internal-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
+  integrity sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==
+  dependencies:
+    es-errors "^1.3.0"
+    hasown "^2.0.2"
+    side-channel "^1.1.0"
+
 ip-address@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
@@ -9091,10 +9441,37 @@ ipaddr.js@^2.1.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.2.0.tgz#d33fa7bac284f4de7af949638c9d68157c6b92e8"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
 
+is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
+  integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-async-function@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.1.1.tgz#3e69018c8e04e73b738793d020bfe884b9fd3523"
+  integrity sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==
+  dependencies:
+    async-function "^1.0.0"
+    call-bound "^1.0.3"
+    get-proto "^1.0.1"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
+
+is-bigint@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.1.0.tgz#dda7a3445df57a42583db4228682eba7c4170672"
+  integrity sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==
+  dependencies:
+    has-bigints "^1.0.2"
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -9103,12 +9480,42 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
+is-boolean-object@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
+  integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
+
+is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
 is-core-module@^2.13.0, is-core-module@^2.16.0, is-core-module@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.1.tgz#2a98801a849f43e2add644fbb6bc6229b19a4ef4"
   integrity sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==
   dependencies:
     hasown "^2.0.2"
+
+is-data-view@^1.0.1, is-data-view@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-data-view/-/is-data-view-1.0.2.tgz#bae0a41b9688986c2188dda6657e56b8f9e63b8e"
+  integrity sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==
+  dependencies:
+    call-bound "^1.0.2"
+    get-intrinsic "^1.2.6"
+    is-typed-array "^1.1.13"
+
+is-date-object@^1.0.5, is-date-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.1.0.tgz#ad85541996fc7aa8b2729701d27b7319f95d82f7"
+  integrity sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -9124,6 +9531,13 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
+
+is-finalizationregistry@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz#eefdcdc6c94ddd0674d9c85887bf93f944a97c90"
+  integrity sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==
+  dependencies:
+    call-bound "^1.0.3"
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -9141,6 +9555,17 @@ is-generator-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
+is-generator-function@^1.0.10:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
+  integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
+  dependencies:
+    call-bound "^1.0.4"
+    generator-function "^2.0.0"
+    get-proto "^1.0.1"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -9166,10 +9591,28 @@ is-interactive@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-2.0.0.tgz#40c57614593826da1100ade6059778d597f16e90"
   integrity sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==
 
+is-map@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
+  integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
+
+is-negative-zero@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
+  integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
 is-network-error@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-network-error/-/is-network-error-1.1.0.tgz#d26a760e3770226d11c169052f266a4803d9c997"
   integrity sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==
+
+is-number-object@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.1.1.tgz#144b21e95a1bc148205dcc2814a9134ec41b2541"
+  integrity sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -9203,10 +9646,56 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
+is-regex@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
+  integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
+  dependencies:
+    call-bound "^1.0.2"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
+is-set@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
+  integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
+
+is-shared-array-buffer@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz#9b67844bd9b7f246ba0708c3a93e34269c774f6f"
+  integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
+  dependencies:
+    call-bound "^1.0.3"
+
 is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-string@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
+  integrity sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
+
+is-symbol@^1.0.4, is-symbol@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.1.1.tgz#f47761279f532e2b05a7024a7506dbbedacd0634"
+  integrity sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==
+  dependencies:
+    call-bound "^1.0.2"
+    has-symbols "^1.1.0"
+    safe-regex-test "^1.1.0"
+
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
+  integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
+  dependencies:
+    which-typed-array "^1.1.16"
 
 is-unicode-supported@^0.1.0:
   version "0.1.0"
@@ -9217,6 +9706,26 @@ is-unicode-supported@^2.0.0, is-unicode-supported@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz#09f0ab0de6d3744d48d265ebb98f65d11f2a9b3a"
   integrity sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==
+
+is-weakmap@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
+  integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
+
+is-weakref@^1.0.2, is-weakref@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.1.tgz#eea430182be8d64174bd96bffbc46f21bf3f9293"
+  integrity sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==
+  dependencies:
+    call-bound "^1.0.3"
+
+is-weakset@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.4.tgz#c9f5deb0bc1906c6d6f1027f284ddf459249daca"
+  integrity sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==
+  dependencies:
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
 
 is-what@^3.14.1:
   version "3.14.1"
@@ -9241,6 +9750,11 @@ is-wsl@^3.1.0:
   integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
   dependencies:
     is-inside-container "^1.0.0"
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -9896,6 +10410,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json5@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^2.1.2, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -10496,7 +11017,7 @@ minimatch@^9.0.4, minimatch@^9.0.5:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -10581,7 +11102,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.3, ms@^2.1.3:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -10916,10 +11437,56 @@ object-assign@^4:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-object-inspect@^1.13.3:
+object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.7:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
+  integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
+    has-symbols "^1.1.0"
+    object-keys "^1.1.1"
+
+object.fromentries@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.8.tgz#f7195d8a9b97bd95cbc1999ea939ecd1a2b00c65"
+  integrity sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+    es-object-atoms "^1.0.0"
+
+object.groupby@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/object.groupby/-/object.groupby-1.0.3.tgz#9b125c36238129f6f7b61954a1e7176148d5002e"
+  integrity sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+
+object.values@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.2.1.tgz#deed520a50809ff7f75a7cfd4bc64c7a038c6216"
+  integrity sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -11038,6 +11605,15 @@ ordered-binary@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.5.3.tgz#8bee2aa7a82c3439caeb1e80c272fd4cf51170fb"
   integrity sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==
+
+own-keys@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
+  integrity sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==
+  dependencies:
+    get-intrinsic "^1.2.6"
+    object-keys "^1.1.1"
+    safe-push-apply "^1.0.0"
 
 oxc-resolver@^1.10.2:
   version "1.12.0"
@@ -11350,6 +11926,11 @@ portfinder@^1.0.28:
   dependencies:
     async "^3.2.6"
     debug "^4.3.6"
+
+possible-typed-array-names@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
+  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
 postcss-calc@^9.0.1:
   version "9.0.1"
@@ -11851,6 +12432,20 @@ reflect-metadata@^0.2.0:
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.2.2.tgz#400c845b6cba87a21f2c65c4aeb158f4fa4d9c5b"
   integrity sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==
 
+reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
+  integrity sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.9"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    get-intrinsic "^1.2.7"
+    get-proto "^1.0.1"
+    which-builtin-type "^1.2.1"
+
 regenerate-unicode-properties@^10.2.0:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz#626e39df8c372338ea9b8028d1f99dc3fd9c3db0"
@@ -11886,6 +12481,18 @@ regex-parser@^2.2.11:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.3.1.tgz#ee3f70e50bdd81a221d505242cb9a9c275a2ad91"
   integrity sha512-yXLRqatcCuKtVHsWrNg0JL3l1zGfdXeEvDa0bdu4tCDQw0RpMDZsqbkyRTUnKMR0tXF627V2oEWjBEaEdqTwtQ==
+
+regexp.prototype.flags@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
+  integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    set-function-name "^2.0.2"
 
 regexpu-core@^6.2.0:
   version "6.2.0"
@@ -11986,7 +12593,7 @@ resolve.exports@2.0.3:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.3.tgz#41955e6f1b4013b7586f873749a635dea07ebe3f"
   integrity sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==
 
-resolve@1.22.11, resolve@^1.22.10:
+resolve@1.22.11, resolve@^1.22.10, resolve@^1.22.4:
   version "1.22.11"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
   integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
@@ -12138,6 +12745,17 @@ rxjs@7.8.2, rxjs@^7.4.0, rxjs@^7.8.0, rxjs@~7.8.0:
   dependencies:
     tslib "^2.1.0"
 
+safe-array-concat@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz#c9e54ec4f603b0bbb8e7e5007a5ee7aecd1538c3"
+  integrity sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.2"
+    get-intrinsic "^1.2.6"
+    has-symbols "^1.1.0"
+    isarray "^2.0.5"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -12147,6 +12765,23 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-push-apply@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz#01850e981c1602d398c85081f360e4e6d03d27f5"
+  integrity sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==
+  dependencies:
+    es-errors "^1.3.0"
+    isarray "^2.0.5"
+
+safe-regex-test@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
+  integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-regex "^1.2.1"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -12477,6 +13112,37 @@ serve-static@^2.2.0:
     parseurl "^1.3.3"
     send "^1.2.0"
 
+set-function-length@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
+set-function-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.2.tgz#16a705c5a0dc2f5e638ca96d8a8cd4e1c2b90985"
+  integrity sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
+    has-property-descriptors "^1.0.2"
+
+set-proto@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/set-proto/-/set-proto-1.0.0.tgz#0760dbcff30b2d7e801fd6e19983e56da337565e"
+  integrity sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+
 setprototypeof@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
@@ -12784,6 +13450,14 @@ stdin-discarder@^0.2.2:
   resolved "https://registry.yarnpkg.com/stdin-discarder/-/stdin-discarder-0.2.2.tgz#390037f44c4ae1a1ae535c5fe38dc3aba8d997be"
   integrity sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==
 
+stop-iteration-iterator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
+  integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
+  dependencies:
+    es-errors "^1.3.0"
+    internal-slot "^1.1.0"
+
 streamroller@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/streamroller/-/streamroller-3.1.5.tgz#1263182329a45def1ffaef58d31b15d13d2ee7ff"
@@ -12844,6 +13518,38 @@ string-width@^8.0.0, string-width@^8.1.0:
   dependencies:
     get-east-asian-width "^1.3.0"
     strip-ansi "^7.1.0"
+
+string.prototype.trim@^1.2.10:
+  version "1.2.10"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz#40b2dd5ee94c959b4dcfb1d65ce72e90da480c81"
+  integrity sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.2"
+    define-data-property "^1.1.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-object-atoms "^1.0.0"
+    has-property-descriptors "^1.0.2"
+
+string.prototype.trimend@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz#62e2731272cd285041b36596054e9f66569b6942"
+  integrity sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.2"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
+
+string.prototype.trimstart@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz#7ee834dda8c7c17eff3118472bb35bfedaa34dde"
+  integrity sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -13241,6 +13947,16 @@ tsconfig-paths-webpack-plugin@4.2.0:
     tapable "^2.2.1"
     tsconfig-paths "^4.1.2"
 
+tsconfig-paths@^3.15.0:
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
+  integrity sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
 tsconfig-paths@^4.1.2:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz#ef78e19039133446d244beac0fd6a1632e2d107c"
@@ -13313,6 +14029,51 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
+typed-array-buffer@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz#a72395450a4869ec033fd549371b47af3a2ee536"
+  integrity sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-typed-array "^1.1.14"
+
+typed-array-byte-length@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz#8407a04f7d78684f3d252aa1a143d2b77b4160ce"
+  integrity sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==
+  dependencies:
+    call-bind "^1.0.8"
+    for-each "^0.3.3"
+    gopd "^1.2.0"
+    has-proto "^1.2.0"
+    is-typed-array "^1.1.14"
+
+typed-array-byte-offset@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz#ae3698b8ec91a8ab945016108aef00d5bff12355"
+  integrity sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    for-each "^0.3.3"
+    gopd "^1.2.0"
+    has-proto "^1.2.0"
+    is-typed-array "^1.1.15"
+    reflect.getprototypeof "^1.0.9"
+
+typed-array-length@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.7.tgz#ee4deff984b64be1e118b0de8c9c877d5ce73d3d"
+  integrity sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==
+  dependencies:
+    call-bind "^1.0.7"
+    for-each "^0.3.3"
+    gopd "^1.0.1"
+    is-typed-array "^1.1.13"
+    possible-typed-array-names "^1.0.0"
+    reflect.getprototypeof "^1.0.6"
+
 typed-assert@^1.0.8:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/typed-assert/-/typed-assert-1.0.9.tgz#8af9d4f93432c4970ec717e3006f33f135b06213"
@@ -13337,6 +14098,16 @@ uglify-js@^3.1.4:
   version "3.19.3"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
+
+unbox-primitive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz#8d9d2c9edeea8460c7f35033a88867944934d1e2"
+  integrity sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==
+  dependencies:
+    call-bound "^1.0.3"
+    has-bigints "^1.0.2"
+    has-symbols "^1.1.0"
+    which-boxed-primitive "^1.1.1"
 
 undici-types@~6.21.0:
   version "6.21.0"
@@ -13812,6 +14583,59 @@ whatwg-url@^5.0.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
+  integrity sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==
+  dependencies:
+    is-bigint "^1.1.0"
+    is-boolean-object "^1.2.1"
+    is-number-object "^1.1.1"
+    is-string "^1.1.1"
+    is-symbol "^1.1.1"
+
+which-builtin-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/which-builtin-type/-/which-builtin-type-1.2.1.tgz#89183da1b4907ab089a6b02029cc5d8d6574270e"
+  integrity sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==
+  dependencies:
+    call-bound "^1.0.2"
+    function.prototype.name "^1.1.6"
+    has-tostringtag "^1.0.2"
+    is-async-function "^2.0.0"
+    is-date-object "^1.1.0"
+    is-finalizationregistry "^1.1.0"
+    is-generator-function "^1.0.10"
+    is-regex "^1.2.1"
+    is-weakref "^1.0.2"
+    isarray "^2.0.5"
+    which-boxed-primitive "^1.1.0"
+    which-collection "^1.0.2"
+    which-typed-array "^1.1.16"
+
+which-collection@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
+  integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
+  dependencies:
+    is-map "^2.0.3"
+    is-set "^2.0.3"
+    is-weakmap "^2.0.2"
+    is-weakset "^2.0.3"
+
+which-typed-array@^1.1.16, which-typed-array@^1.1.19:
+  version "1.1.20"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.20.tgz#3fdb7adfafe0ea69157b1509f3a1cd892bd1d122"
+  integrity sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
 
 which@^1.2.14:
   version "1.3.1"


### PR DESCRIPTION
- Introduce `saveArticleVersion` method in `ArticleService` and `ArticleApiService`.
- Add `SaveArticleVersionRequestDto` and `SaveArticleVersionResponseDto` models.
- Update `ArticleEditComponent` with save and cancel actions, including state management and notification handling.
- Enhance test coverage for article version save functionality.