### PR TITLE
refactor(links): update LinksApiService to JSON requests and improve …

### DIFF
--- a/apps/client/src/app/services/links/links-api.service.spec.ts
+++ b/apps/client/src/app/services/links/links-api.service.spec.ts
@@ -6,6 +6,8 @@ import {
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { LinksApiService } from './links-api.service';
 
+const CHECK_URL = '/api/wiki-links/check';
+
 describe('LinksApiService', () => {
     let spectator: SpectatorService<LinksApiService>;
     let httpController: HttpTestingController;
@@ -29,45 +31,34 @@ describe('LinksApiService', () => {
     });
 
     describe('checkLinks', () => {
-        it('should send POST request to /api/links/check', () => {
+        it('should send POST request to /api/wiki-links/check', () => {
             spectator.service.checkLinks(['link1']).subscribe();
 
-            const req = httpController.expectOne('/api/links/check');
+            const req = httpController.expectOne(CHECK_URL);
             expect(req.request.method).toBe('POST');
-            req.flush({ link1: { isExist: true } });
+            req.flush({ success: true, data: { link1: { isExist: true } } });
         });
 
-        it('should send links as URL-encoded body with links[] keys', () => {
-            spectator.service
-                .checkLinks(['link1', 'link2'])
-                .subscribe();
+        it('should send links as JSON body', () => {
+            spectator.service.checkLinks(['link1', 'link2']).subscribe();
 
-            const req = httpController.expectOne('/api/links/check');
-            expect(req.request.body).toBe('links%5B%5D=link1&links%5B%5D=link2');
+            const req = httpController.expectOne(CHECK_URL);
+            expect(req.request.body).toEqual({ links: ['link1', 'link2'] });
             req.flush({
-                link1: { isExist: true },
-                link2: { isExist: false },
+                success: true,
+                data: {
+                    link1: { isExist: true },
+                    link2: { isExist: false },
+                },
             });
         });
 
-        it('should set Content-Type header to application/x-www-form-urlencoded', () => {
+        it('should send request with credentials', () => {
             spectator.service.checkLinks(['link1']).subscribe();
 
-            const req = httpController.expectOne('/api/links/check');
-            expect(req.request.headers.get('Content-Type')).toBe(
-                'application/x-www-form-urlencoded'
-            );
-            req.flush({ link1: { isExist: true } });
-        });
-
-        it('should set X-Requested-With header', () => {
-            spectator.service.checkLinks(['link1']).subscribe();
-
-            const req = httpController.expectOne('/api/links/check');
-            expect(req.request.headers.get('X-Requested-With')).toBe(
-                'XMLHttpRequest'
-            );
-            req.flush({ link1: { isExist: true } });
+            const req = httpController.expectOne(CHECK_URL);
+            expect(req.request.withCredentials).toBe(true);
+            req.flush({ success: true, data: { link1: { isExist: true } } });
         });
 
         it('should map response to Record<string, boolean>', () => {
@@ -76,23 +67,42 @@ describe('LinksApiService', () => {
                 result = r;
             });
 
-            httpController.expectOne('/api/links/check').flush({
-                link1: { isExist: true },
-                link2: { isExist: false },
+            httpController.expectOne(CHECK_URL).flush({
+                success: true,
+                data: {
+                    link1: { isExist: true },
+                    link2: { isExist: false },
+                },
             });
 
             expect(result).toEqual({ link1: true, link2: false });
         });
 
-        it('should handle empty response', () => {
+        it('should handle empty response data', () => {
             let result: Record<string, boolean> | undefined;
             spectator.service.checkLinks(['link1']).subscribe(r => {
                 result = r;
             });
 
-            httpController.expectOne('/api/links/check').flush({});
+            httpController.expectOne(CHECK_URL).flush({
+                success: true,
+                data: {},
+            });
 
             expect(result).toEqual({});
+        });
+
+        it('should throw when response.data is undefined', done => {
+            spectator.service.checkLinks(['link1']).subscribe({
+                error: (err: Error) => {
+                    expect(err.message).toContain('Response data is undefined');
+                    done();
+                },
+            });
+
+            httpController
+                .expectOne(CHECK_URL)
+                .flush({ success: true, data: undefined });
         });
     });
 });

--- a/apps/client/src/app/services/links/links-api.service.ts
+++ b/apps/client/src/app/services/links/links-api.service.ts
@@ -1,6 +1,7 @@
 import { environment } from '../../../environments/environment';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
+import { ApiResponse, assertIsDefined } from '@drevo-web/shared';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -27,26 +28,17 @@ export class LinksApiService {
      * @returns Observable with record of link existence statuses
      */
     checkLinks(links: string[]): Observable<Record<string, boolean>> {
-        let body = new HttpParams();
-        links.forEach(link => {
-            body = body.append('links[]', link);
-        });
-
         return this.http
-            .post<LinksCheckResponse>(
-                `${this.apiUrl}/api/links/check`,
-                body.toString(),
-                {
-                    headers: {
-                        'Content-Type': 'application/x-www-form-urlencoded',
-                        'X-Requested-With': 'XMLHttpRequest',
-                    },
-                }
+            .post<ApiResponse<LinksCheckResponse>>(
+                `${this.apiUrl}/api/wiki-links/check`,
+                { links },
+                { withCredentials: true }
             )
             .pipe(
-                map(raw => {
+                map(response => {
+                    assertIsDefined(response.data, 'Response data is undefined');
                     const result: Record<string, boolean> = {};
-                    Object.entries(raw).forEach(([key, value]) => {
+                    Object.entries(response.data).forEach(([key, value]) => {
                         result[key] = value.isExist;
                     });
                     return result;


### PR DESCRIPTION
…handling

- Switch `checkLinks` requests to JSON body format and update URL (`/api/wiki-links/check`).
- Add `withCredentials` for request authentication.
- Enhance response handling with stricter validation (`assertIsDefined`) and clear error output.
- Update unit tests for new request format, response structure, and error scenarios.