### PR TITLE
ci(cd): add deployment URLs to release notes and beta summary

### DIFF
--- a/.github/workflows/cd-main-beta.yml
+++ b/.github/workflows/cd-main-beta.yml
@@ -142,10 +142,18 @@ jobs:
 
             - name: Notify deployment
               if: always()
+              env:
+                  BETA_URL: ${{ vars.BETA_URL }}
               run: |
                   if [ "${{ job.status }}" == "success" ]; then
                     echo "Beta deployment successful"
+                    echo "### ✅ Beta deployed" >> $GITHUB_STEP_SUMMARY
+                    echo "**Version**: ${{ steps.build.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+                    if [ -n "$BETA_URL" ]; then
+                      echo "**URL**: $BETA_URL" >> $GITHUB_STEP_SUMMARY
+                    fi
                   else
                     echo "Beta deployment failed"
+                    echo "### ❌ Beta deployment failed" >> $GITHUB_STEP_SUMMARY
                     exit 1
                   fi

--- a/.github/workflows/cd-main-release.yml
+++ b/.github/workflows/cd-main-release.yml
@@ -176,11 +176,10 @@ jobs:
 
                       **Deployed**: ${{ steps.get_timestamp.outputs.timestamp }}
                       **Environment**: Release
+                      ${{ vars.RELEASE_URL && format('**URL**: {0}', vars.RELEASE_URL) || '' }}
 
                       **Changes in this release:**
                       ${{ steps.changelog.outputs.changelog }}
-
-                      **Deployment**: Files deployed successfully
                   draft: false
                   prerelease: false
                   files: |


### PR DESCRIPTION
## Summary
- Add `RELEASE_URL` environment variable to GitHub Release body (visible on release page)
- Add `BETA_URL` to beta workflow job summary with version info
- URLs are optional — if env variables are not set, nothing is shown

## Setup required
Add variables in **Settings → Environments → Variables**:
- `release` environment: `RELEASE_URL`
- `beta` environment: `BETA_URL`

## Test plan
- [ ] Set `RELEASE_URL` in release environment, create a tag — verify URL appears in release notes
- [ ] Set `BETA_URL` in beta environment, push to main — verify URL appears in job summary
- [ ] Verify that without variables set, no empty lines or broken formatting appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)