### PR TITLE
docs: update documentation for branch migration (Phase 11)

### DIFF
--- a/.claude/skills/review-branch/SKILL.md
+++ b/.claude/skills/review-branch/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: review-branch
-description: Review current branch changes against standalone branch
+description: Review current branch changes against main branch
 ---
 
 # Review Branch
 
-Review all changes on the current branch compared to `standalone`.
+Review all changes on the current branch compared to `main`.
 
 ## Context
 
 **Current branch:** !`git rev-parse --abbrev-ref HEAD`
 
 **Changed files:**
-!`git diff standalone...HEAD --name-status`
+!`git diff main...HEAD --name-status`
 
 **Diff:**
-!`git diff standalone...HEAD`
+!`git diff main...HEAD`
 
 ## Instructions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,7 +15,7 @@ Nx monorepo migrating from Yii1 PHP to Angular 21 + Node.js. Uses zoneless chang
 
 **Key patterns**: Standalone components only, `inject()` for DI, `ChangeDetectionStrategy.OnPush`, lazy routes via `loadComponent()`.
 
-**Branches**: `standalone` (default) - full Angular app development; `main` - iframe mode with `/new` prefix.
+**Branches**: `main` (default) - active development. Push triggers beta deploy, tag `X.Y.Z` triggers release. `iframe` - frozen legacy (manual deploy only).
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,11 @@
 
 **Drevo-Web** — Nx monorepo with Angular 21 application. Migration from legacy Yii1 app to modern stack.
 
+## Branches
+
+- `main` — active development, default branch. Push triggers beta deploy (drevo-beta, port 4010). Tag `X.Y.Z` triggers release deploy (drevo-release, port 4011).
+- `iframe` — frozen legacy (old Yii-era wrapper). CI runs automatically on PR; CD is manual-only via workflow_dispatch. Hotfix tags: `iframe-X.Y.Z`.
+
 ## Tech Stack
 
 | Category | Technology |

--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ The project uses GitHub Actions for CI/CD.
 
 ### Branches
 
-- **`standalone`** — default branch, active development of the standalone Angular application
-- `main` — PR target branch for standalone development
-- `staging` — staging deployment
+- **`main`** — default branch, active development. Push triggers beta deploy. Tag `X.Y.Z` triggers release deploy.
+- `iframe` — frozen legacy (old Yii-era wrapper). CD is manual-only via `workflow_dispatch`. Hotfix tags: `iframe-X.Y.Z`.
 
 ### Workflows
 
@@ -122,9 +121,9 @@ The project uses GitHub Actions for CI/CD.
 |----------|------|---------|
 | CI | `ci.yml` | Push & PR to all branches |
 | Coverage | `coverage.yml` | After CI |
-| Staging Deploy | `cd-staging.yml` | Push to `staging` |
-| Production Deploy | `cd-production.yml` | Push to `production` |
-| Standalone Build | `standalone.yml` | Manual |
+| Beta Deploy | `cd-main-beta.yml` | Push to `main` |
+| Release Deploy | `cd-main-release.yml` | Tag `X.Y.Z` on `main` |
+| Iframe Release | `cd-iframe-release.yml` | Manual (`workflow_dispatch`) |
 | Security Scan | `security-scan.yml` | Push & PR |
 
 ### Security Scanning
@@ -137,27 +136,28 @@ Automated security scanning to prevent secrets from being committed:
 
 ### Version Management
 
-- Semantic versioning with automatic tags on production deployments
-- Version bump via commit messages: `#major`, `#minor`, default is patch
+- **Beta**: date-based versions (`yymmdd-HHMM`), automatic on push to `main`
+- **Release**: semantic versioning (`X.Y.Z`), triggered by git tag + GitHub Release
 
 ### Branch Protection
 
-- Protected branches: `standalone`, `staging`, `main`
-- Required pull request reviews and passing status checks
+- Protected branch: `main` (required PR reviews, passing status checks)
 - Feature branches deleted after merge
 
 ## Deployment
 
 Atomic deployment via symlink switching, managed by PM2.
 
+| PM2 App | Port | Role | Branch |
+|---------|------|------|--------|
+| `drevo-production` | 4002 | iframe release (legacy) | `iframe` |
+| `drevo-beta` | 4010 | main beta (date version) | `main` |
+| `drevo-release` | 4011 | main release (semver) | `main` tag `X.Y.Z` |
+
 ### Prerequisites
 
-1. GitHub repository secrets:
-   - `SSH_PRIVATE_KEY`, `SSH_KNOWN_HOSTS`
-   - `STAGING_SSH_USER`, `STAGING_SSH_HOST`, `STAGING_PATH`
-   - `PRODUCTION_SSH_USER`, `PRODUCTION_SSH_HOST`, `PRODUCTION_PATH`
-
-2. GitHub environments: `staging`, `production`
+1. GitHub repository secrets: `SSH_PRIVATE_KEY`, `SSH_KNOWN_HOSTS`, `SSH_USER`, `SSH_HOST`, `SSH_PORT`
+2. GitHub environments: `beta`, `release`, `production`
 
 ### Manual Deployment
 
@@ -166,5 +166,5 @@ Atomic deployment via symlink switching, managed by PM2.
 yarn build
 
 # Deploy using deploy script
-./scripts/deploy.sh /path/to/deploy environment
+./scripts/deploy.sh <version> <pm2-app-name> <symlink-path> <environment>
 ```

--- a/SCRIPTS-GUIDE.md
+++ b/SCRIPTS-GUIDE.md
@@ -11,12 +11,13 @@ This guide explains the different scripts available for building, deploying, and
 
 **Usage**:
 ```bash
-# New format (recommended)
+# Examples
+./scripts/deploy.sh "250413-1430" "drevo-beta" "~/releases/beta-current" "beta"
+./scripts/deploy.sh "1.2.0" "drevo-release" "~/releases/release-current" "release"
 ./scripts/deploy.sh "1.2.0" "drevo-production" "~/releases/production-current" "production"
-./scripts/deploy.sh "20240923-0900" "drevo-staging" "~/releases/staging-current" "staging"
 
 # Dry run mode
-./scripts/deploy.sh "1.2.0" "drevo-production" "~/releases/production-current" "production" --dry-run
+./scripts/deploy.sh "1.2.0" "drevo-release" "~/releases/release-current" "release" --dry-run
 ```
 
 **What it does**:
@@ -76,9 +77,9 @@ Each environment uses different paths and ports:
 
 | Environment | Base Path | Port | PM2 App Name |
 |-------------|-----------|------|--------------|
-| **Production** | `/` | 4002 | drevo-production |
-| **Staging** | `/staging` | 4001 | drevo-staging |
-| **Standalone** | `/` | 4010 | drevo-standalone |
+| **Production** (iframe) | `/` | 4002 | drevo-production |
+| **Beta** | `/` | 4010 | drevo-beta |
+| **Release** | `/` | 4011 | drevo-release |
 | **Local dev** | `/` | 4200 | N/A |
 
 ---
@@ -89,9 +90,9 @@ Each environment uses different paths and ports:
 # 🔧 LOCAL DEVELOPMENT
 yarn serve                # Start dev server (http://localhost:4200)
 
-# 🚀 PRODUCTION DEPLOYMENT  
-./scripts/deploy.sh "1.2.0" "drevo-production" "~/releases/production-current" "production"
-./scripts/deploy.sh "20240923-0900" "drevo-staging" "~/releases/staging-current" "staging"
+# 🚀 DEPLOYMENT  
+./scripts/deploy.sh "250413-1430" "drevo-beta" "~/releases/beta-current" "beta"
+./scripts/deploy.sh "1.2.0" "drevo-release" "~/releases/release-current" "release"
 
 # 📦 MANUAL BUILD + START
 yarn build && yarn start
@@ -104,4 +105,4 @@ yarn build && yarn start
 - **deploy.sh**: Production deployment only, uses atomic symlinks and PM2
 - **yarn serve**: For local development with HMR
 - **yarn build + start**: For testing production SSR locally
-- Staging uses `--base-href=/staging/` passed via CI/CD pipeline
+- Beta and release use `--base-href=/` passed via CI/CD pipeline

--- a/docs/plans/branch-migration/plan.md
+++ b/docs/plans/branch-migration/plan.md
@@ -1,5 +1,7 @@
 # Branch migration: standalone → main, iframe freeze, new release pipeline
 
+> **Completed 2026-04-13.** This document is kept as a historical artifact.
+
 ## 1. Overview
 
 ### Goal
@@ -643,7 +645,7 @@ pm2 resurrect
 
 ---
 
-### Phase 8 — Smoke-test beta deploy
+### Phase 8 — Smoke-test beta deploy ✅
 
 **Goal**: убедиться, что `cd-main-beta.yml` срабатывает и реально деплоит в drevo-beta.
 
@@ -681,7 +683,7 @@ pm2 resurrect
 
 ---
 
-### Phase 9 — Smoke-test release deploy
+### Phase 9 — Smoke-test release deploy ✅
 
 **Goal**: проверить, что `cd-main-release.yml` корректно обрабатывает тэг `[0-9]*`, деплоит в `drevo-release`, создаёт GitHub Release и грузит source maps в Sentry.
 
@@ -712,7 +714,7 @@ pm2 resurrect
 
 ---
 
-### Phase 10 — Cleanup
+### Phase 10 — Cleanup ✅
 
 **Goal**: убрать временные подпорки, удалить старый GH environment.
 

--- a/docs/pm2-setup.md
+++ b/docs/pm2-setup.md
@@ -120,19 +120,19 @@ pm2 startup
 pm2 status
 
 # Детальная информация о приложении
-pm2 show drevo-standalone
+pm2 show drevo-beta
 
 # Логи приложения
-pm2 logs drevo-standalone
+pm2 logs drevo-beta
 
 # Рестарт приложения
-pm2 restart drevo-standalone
+pm2 restart drevo-beta
 
 # Остановка приложения
-pm2 stop drevo-standalone
+pm2 stop drevo-beta
 
 # Удаление приложения из PM2
-pm2 delete drevo-standalone
+pm2 delete drevo-beta
 
 # Мониторинг в реальном времени
 pm2 monit

--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -122,8 +122,8 @@ git commit --no-verify -m "your message"
 ## Continuous Monitoring
 
 The GitHub Action runs automatically on:
-- Every push to `main`, `standalone`, or `feature/*` branches
-- Every pull request to `main` or `standalone`
+- Every push to `main`, `iframe`, or `feature/*` branches
+- Every pull request to `main` or `iframe`
 
 Check results in:
 - **Actions tab**: See workflow runs

--- a/docs/server-github-setup.md
+++ b/docs/server-github-setup.md
@@ -196,21 +196,24 @@ Click **"New repository variable"** and add:
 
 Navigate to: **Settings → Environments**
 
-#### Create Staging Environment:
+#### Create Beta Environment:
 1. Click **"New environment"**
-2. Name: `staging`
+2. Name: `beta`
 3. **Protection rules**: None (leave empty)
-4. Click **"Configure environment"**
-5. No additional configuration needed
+4. **Deployment branches**: `main` only
 
-#### Create Production Environment:
+#### Create Release Environment:
+1. Click **"New environment"**
+2. Name: `release`
+3. **Protection rules**: None (leave empty)
+4. **Deployment branches**: Selected branches and tags — add rule: `X.Y.Z` (semver tags)
+
+#### Create Production Environment (iframe legacy):
 1. Click **"New environment"**
 2. Name: `production`
 3. **Protection rules**:
    - ✅ **Required reviewers**: Add yourself
-   - ✅ **Deployment branches**: Selected branches and tags
-     - Add rule: `main`
-     - Add rule: `v*`
+   - ✅ **Deployment branches**: `iframe` only
 4. Click **"Save protection rules"**
 
 ## Part 4: Verification Tests


### PR DESCRIPTION
## Summary

- Updated all documentation to reflect the completed `standalone` → `main` branch migration
- Replaced `standalone` branch/PM2 references with `main`/`iframe`/`drevo-beta`/`drevo-release`
- Added `Branches` section to `CLAUDE.md`
- Marked Phases 8–10 as completed and the entire migration plan as finished

## Changed files

- `README.md` — branches, workflows, PM2 table, version management
- `CLAUDE.md` — new Branches section
- `SCRIPTS-GUIDE.md` — environment table, deploy examples
- `docs/pm2-setup.md` — `drevo-standalone` → `drevo-beta`
- `docs/security-scanning.md` — `standalone` → `iframe`
- `docs/server-github-setup.md` — environments: beta, release, production
- `.github/copilot-instructions.md` — branch descriptions
- `.claude/skills/review-branch/SKILL.md` — `standalone` → `main`
- `docs/plans/branch-migration/plan.md` — Phases 8–10 ✅, "Completed 2026-04-13"

## Test plan

- [ ] Verify no remaining `standalone` branch references in docs (only Angular standalone component mentions)
- [ ] Verify CLAUDE.md Branches section is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)