### PR TITLE
chore: bump GitHub Actions to node 24

### DIFF
--- a/.github/workflows/cd-main-beta.yml
+++ b/.github/workflows/cd-main-beta.yml
@@ -13,11 +13,11 @@ jobs:
     ci:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'
@@ -51,9 +51,9 @@ jobs:
         environment: beta
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'

--- a/.github/workflows/cd-main-release.yml
+++ b/.github/workflows/cd-main-release.yml
@@ -37,7 +37,7 @@ jobs:
                   echo "::error::workflow_dispatch for releases is only allowed from main (current: ${{ github.ref }})"
                   exit 1
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
                   ref: main
@@ -120,7 +120,7 @@ jobs:
                       echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
                   fi
 
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
                   ref: ${{ steps.version.outputs.tag }}
@@ -146,7 +146,7 @@ jobs:
                     echo "EOF" >> $GITHUB_OUTPUT
                   fi
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'
@@ -235,7 +235,7 @@ jobs:
                   version: ${{ steps.version.outputs.version }}
 
             - name: Create GitHub Release
-              uses: softprops/action-gh-release@v1
+              uses: softprops/action-gh-release@v2
               with:
                   tag_name: ${{ steps.version.outputs.tag }}
                   name: Release ${{ steps.version.outputs.version }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,9 +18,9 @@ jobs:
     coverage:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'

--- a/.github/workflows/playwright-cross-browser.yml
+++ b/.github/workflows/playwright-cross-browser.yml
@@ -23,9 +23,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,9 +14,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: '20'
                   cache: 'yarn'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0 # Fetch all history for full scan
 


### PR DESCRIPTION
- update actions/checkout to v5 and actions/setup-node to v5 in all workflows
- update softprops/action-gh-release to v2 in release workflow