### PR TITLE
feat: set default file permissions during deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,9 @@
 
 set -euo pipefail
 
+# Files created during deploy must be readable by nginx (www-data group via setgid on releases/).
+umask 027
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
- Add `umask 027` to ensure files created during deploy are group-readable (www-data).